### PR TITLE
Added a simple locate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Pending
+- Add vacuum start,stop,locate,pause service calls
+  - `start` is equivalent to `turn_on` (ie start a cleaning cycle)
+  - `stop` and `pause` are equivalent to `turn_off` (ie stop a cleaning cycle)
+  - locate turns the LED on for 2 seconds and off again
+
 ## v0.1.0
 - Major refactor of HA Manager, Entity Manager and API (code cleanup)
 - AWS IOT Broker works with asynchronous operations

--- a/custom_components/mydolphin_plus/component/managers/home_assistant.py
+++ b/custom_components/mydolphin_plus/component/managers/home_assistant.py
@@ -466,7 +466,7 @@ class MyDolphinPlusHomeAssistantManager(HomeAssistantManager):
                                            attributes,
                                            device_name,
                                            entity_description,
-                                           self._set_led_enabled)
+                                           self.set_led_enabled)
 
         except Exception as ex:
             self._log_exception(
@@ -525,7 +525,7 @@ class MyDolphinPlusHomeAssistantManager(HomeAssistantManager):
     def set_led_intensity(self, intensity: int):
         self.api.set_led_intensity(intensity)
 
-    def _set_led_enabled(self, is_enabled: bool):
+    def set_led_enabled(self, is_enabled: bool):
         self.api.set_led_enabled(is_enabled)
 
     def get_fan_speed(self):

--- a/custom_components/mydolphin_plus/vacuum.py
+++ b/custom_components/mydolphin_plus/vacuum.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 from abc import ABC
 import logging
-from typing import Any
 import time
-
+from typing import Any
 
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
 from homeassistant.core import HomeAssistant

--- a/custom_components/mydolphin_plus/vacuum.py
+++ b/custom_components/mydolphin_plus/vacuum.py
@@ -6,9 +6,10 @@ https://github.com/sh00t2kill/dolphin-robot
 from __future__ import annotations
 
 from abc import ABC
-import logging
 from typing import Any
+import logging
 import time
+
 
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
 from homeassistant.core import HomeAssistant

--- a/custom_components/mydolphin_plus/vacuum.py
+++ b/custom_components/mydolphin_plus/vacuum.py
@@ -6,8 +6,8 @@ https://github.com/sh00t2kill/dolphin-robot
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any
 import logging
+from typing import Any
 import time
 
 
@@ -15,7 +15,7 @@ from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeatu
 from homeassistant.core import HomeAssistant
 
 from .component.helpers.const import *
-from .component.models.mydolphin_plus_entity import MyDolphinPlusEntity
+from .component.models.mydolphin_plus_entity import MyDolphinPlusEntit
 from .core.models.base_entity import async_setup_base_entry
 from .core.models.entity_data import EntityData
 

--- a/custom_components/mydolphin_plus/vacuum.py
+++ b/custom_components/mydolphin_plus/vacuum.py
@@ -14,7 +14,7 @@ from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeatu
 from homeassistant.core import HomeAssistant
 
 from .component.helpers.const import *
-from .component.models.mydolphin_plus_entity import MyDolphinPlusEntit
+from .component.models.mydolphin_plus_entity import MyDolphinPlusEntity
 from .core.models.base_entity import async_setup_base_entry
 from .core.models.entity_data import EntityData
 

--- a/custom_components/mydolphin_plus/vacuum.py
+++ b/custom_components/mydolphin_plus/vacuum.py
@@ -101,6 +101,9 @@ class MyDolphinPlusVacuum(StateVacuumEntity, MyDolphinPlusEntity, ABC):
     async def async_stop(self, **kwargs: Any) -> None:
         self.ha.set_power_state(False)
 
+    async def pause(self, **kwargs: Any) -> None:
+        self.ha.set_power_state(False)
+
     async def async_toggle(self, **kwargs: Any) -> None:
         is_on = self.entity.state == PWS_STATE_ON
 

--- a/custom_components/mydolphin_plus/vacuum.py
+++ b/custom_components/mydolphin_plus/vacuum.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from abc import ABC
 import logging
 from typing import Any
+import time
 
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
 from homeassistant.core import HomeAssistant
@@ -81,6 +82,12 @@ class MyDolphinPlusVacuum(StateVacuumEntity, MyDolphinPlusEntity, ABC):
 
             if value == fan_speed:
                 self.ha.set_cleaning_mode(key)
+
+    def locate(self, **kwargs: Any) -> None:
+        self.ha.set_led_enabled(True)
+        time.sleep(2)
+        self.ha.set_led_enabled(False)
+
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         self.ha.set_power_state(True)


### PR DESCRIPTION
A number of vacuum integrations and custom cards call for a locate function.

Added a simple one, that turns on the LED, waits, turns it off again.