### PR TITLE
Fix freeze after publishing message with AWS IoT SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.0.10
+
+- Update manifest requirements to use only AWS IoT Device SDK v2
+- Fix parameter of callback to the right convention
+- Fix AWS IoT MQTT publish message validation and QoS
+- Change clean_session parameter to start a new session on every attempt to connect
+- Set the AWS Client ID to the entry ID instead of randomize on every attempt to connect
+- Set message being sent while publishing empty message to empty JSON instead of empty string
+
 ## v1.0.9
 
 - Upgrade AWS IoT Device SDK to v2

--- a/custom_components/mydolphin_plus/manifest.json
+++ b/custom_components/mydolphin_plus/manifest.json
@@ -8,6 +8,6 @@
   "documentation": "https://github.com/sh00t2kill/dolphin-robot",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/sh00t2kill/dolphin-robot/issues",
-  "requirements": ["awscrt~=0.20.2", "awsiotsdk~=1.21.0"],
-  "version": "1.0.9"
+  "requirements": ["awsiotsdk"],
+  "version": "1.0.10"
 }


### PR DESCRIPTION
- Update manifest requirements to use only AWS IoT Device SDK v2
- Fix parameter of callback to the right convention
- Fix AWS IoT MQTT publish message validation and QoS
- Change clean_session parameter to start a new session on every attempt to connect
- Set the AWS Client ID to the entry ID instead of randomize on every attempt to connect
- Set message being sent while publishing empty message to empty JSON instead of empty string
