### PR TITLE
Fix TypeError when last_token_fetch is None in _generate_aws_token

### DIFF
--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -464,6 +464,8 @@ class RestAPI:
             # Check rate limiting
             now = datetime.now().timestamp()
             last_fetch = self._config_manager.last_token_fetch
+            if last_fetch is None:
+                last_fetch = 0
             time_since_last = now - last_fetch
 
             if time_since_last < MIN_TOKEN_FETCH_INTERVAL.total_seconds():


### PR DESCRIPTION
## Description

Fixes a `TypeError` in `_generate_aws_token` that occurs when 
`last_token_fetch` is `None` (default state on first integration 
load before any token has been fetched).

## Error

ERROR (MainThread) [custom_components.mydolphin_plus.managers.rest_api]
Failed to retrieve AWS token from service,
Error: unsupported operand type(s) for -: 'float' and 'NoneType'
This error blocks the integration on a fresh install or after config 
reset, leaving the vacuum entity stuck as `unavailable`.

## Root cause

`last_token_fetch` is only set after the first successful token fetch, 
so it's `None` on first run. The rate limiting check then fails:

```python
last_fetch = self._config_manager.last_token_fetch
time_since_last = now - last_fetch  # TypeError if None
```

Note: the same value is properly handled with `if last_fetch > 0` 
in `_handle_client_error` later in this same file, so this fixes a 
missing edge case handling.

## Fix

Initialize `last_fetch` to `0` (epoch) when `None`, treating "never 
fetched" as "fetched a very long time ago", which correctly bypasses 
the rate limit on first call.

## Tested

Tested locally on HA 2026.5 with Dolphin T60 robot, integration v1.0.24.

**Before:** Integration stuck in "unavailable" with the error 
repeating every minute.

**After:** Successfully fetched AWS IoT credentials and connected. 
Robot becomes available and operates normally.