### PR TITLE
Replace login with Cognito OTP flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,17 @@ Integration with MyDolphin Plus to monitor and control your robot
 
 [Changelog](https://github.com/sh00t2kill/dolphin-robot/blob/master/CHANGELOG.md)
 
-## Important note RE setup
+## Authentication
 
-Given the OTP implementation on the app, there is currently no way to support this in HA. There is, however, a manual way to create a new user account with a password. This is done via curl
+Authentication uses the same email-OTP flow as the official MyDolphin Plus mobile app:
 
-```
-curl -X POST "https://mbapp18.maytronics.com/api/users/register/" \
-     -H "appkey: 346BDE92-53D1-4829-8A2E-B496014B586C" \
-     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
-     --data-urlencode 'email=<EMAIL>' \
-     --data-urlencode 'password=<PASSWORD>' \
-     --data-urlencode 'firstName=<FIRST NAME' \
-     --data-urlencode 'lastName=<LAST NAME>'
-```
+1. Enter your account email when adding the integration.
+2. Maytronics emails a one-time login code.
+3. Enter the code in Home Assistant — the integration exchanges it for a refresh token and connects to the robot.
 
-Create this account, changing your user details. Once you have done this, login to the mobile app using this account, and it will be "uplifted" to OTP. Add your robot. You can then add this integration using this username and password.
+The refresh token is reused on every Home Assistant restart and silently renewed (~hourly), so you should only need to re-enter an OTP if the refresh token expires (Cognito default ~30 days) or you remove and re-add the integration.
+
+> **Upgrading from a previous version (≤ 1.0.23):** the legacy email/password login endpoint has been retired by Maytronics. After updating, **remove the integration and re-add it** to go through the OTP flow.
 
 ## How to
 
@@ -39,30 +35,27 @@ Create this account, changing your user details. Once you have done this, login 
 
 ###### Basic configuration (Configuration -> Integrations -> Add MyDolphin Plus)
 
-| Fields name | Type    | Required | Default | Description                                   |
-| ----------- | ------- | -------- | ------- | --------------------------------------------- |
-| Username    | Textbox | -        |         | Username of dashboard user for MyDolphin Plus |
-| Password    | Textbox | -        |         | Password of dashboard user for MyDolphin Plus |
+| Field      | Type    | Required | Description                                                                                |
+| ---------- | ------- | -------- | ------------------------------------------------------------------------------------------ |
+| Title      | Textbox | yes      | Display name for the integration entry                                                     |
+| Email      | Textbox | yes      | Email of your MyDolphin Plus account — Maytronics emails a login code to this address      |
+| Login code | Textbox | yes      | The one-time code from the email, entered on the second step of the config flow            |
 
 ###### Configuration validations
 
-Upon submitting the form of creating an integration or updating options,
+Upon submitting the form, the integration verifies the credentials by:
 
-Component will try to log in into the MyDolphin Plus to verify new settings, following errors can appear:
+1. Triggering Cognito `CUSTOM_AUTH` (sends the OTP email).
+2. Exchanging the submitted OTP for an `IdToken` + `RefreshToken`.
+3. Calling `apps.maytronics.com/mobapi/user/authenticate-user/` to confirm the account has a paired robot.
 
-- Integration already configured with the same title
-- Invalid server details - Cannot reach the server
+The following errors can appear:
 
-###### Encryption key got corrupted
-
-If a persistent notification popped up with the following message:
-
-```
-Encryption key got corrupted, please remove the integration and re-add it
-```
-
-It means that encryption key was modified from outside the code,
-Please remove the integration and re-add it to make it work again.
+- **Invalid account** — the email is empty or rejected by Cognito (no such user)
+- **Failed to send login code, check the email and try again** — Cognito refused to send an OTP (rate limit or unknown user)
+- **Invalid or expired login code** — the OTP is wrong, expired, or was used already
+- **Invalid server details** — could not reach Cognito or `apps.maytronics.com`
+- **Integration already configured with the name** — an entry with that title already exists
 
 #### Run as CLI
 
@@ -76,9 +69,10 @@ Please remove the integration and re-add it to make it work again.
 
 | Environment Variable | Type    | Default | Description                                                                                                               |
 | -------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Username             | String  | -       | Username used for MyDolphin Plus                                                                                          |
-| Password             | String  | -       | Password used for MyDolphin Plus                                                                                          |
+| Username             | String  | -       | Email of your MyDolphin Plus account (used to trigger Cognito OTP)                                                        |
 | DEBUG                | Boolean | False   | Setting to True will present DEBUG log level message while testing the code, False will set the minimum log level to INFO |
+
+> CLI use requires interactively entering an OTP from the email Maytronics sends — the legacy username/password login is no longer accepted.
 
 ## HA Components
 
@@ -223,57 +217,11 @@ Please attach also diagnostic details of the integration, available in:
 <br />See this link for further information:
 <br />https://www.home-assistant.io/docs/configuration/troubleshooting/
 
-### Invalid Token
+### Refresh token expired
 
-In case you have referenced to that section, something went wrong with the encryption key,
-Encryption key should be located in `.storage/mydolphin_plus.config.json` file under `data.key` property,
-below are the steps to solve that issue.
+If the integration logs `EXPIRED_TOKEN` and stops loading, the stored Cognito `RefreshToken` is no longer valid (it has expired or been invalidated server-side). Remove and re-add the integration to go through the OTP flow again.
 
-#### File not exists or File exists, data.key is not
-
-Please report as issue
-
-#### File exists, data.key is available
-
-Example:
-
-```json
-{
-  "version": 1,
-  "minor_version": 1,
-  "key": "mydolphin_plus.config.json",
-  "data": {
-    "key": "ox-qQsAiHb67Kz3ypxY19uU2_YwVcSjvdbaBVHZJQFY=",
-    "b8fa11c50331d2647b8aa7e37935efeb": {
-      "locating": false,
-      "aws-token-encrypted-key": "AWS_TOKEN"
-    }
-  }
-}
-```
-
-OR
-
-```json
-{
-  "version": 1,
-  "minor_version": 1,
-  "key": "mydolphin_plus.config.json",
-  "data": {
-    "key": "ox-qQsAiHb67Kz3ypxY19uU2_YwVcSjvdbaBVHZJQFY="
-  }
-}
-```
-
-1. Remove the integration
-2. Delete the file
-3. Restart HA
-4. Try to re-add the integration
-5. If still happens - report as issue
-
-#### File exists, key is available under one of the entry configurations
-
-Example:
+The token state lives in `.storage/mydolphin_plus.config.json`, keyed by the entry id:
 
 ```json
 {
@@ -282,18 +230,17 @@ Example:
   "key": "mydolphin_plus.config.json",
   "data": {
     "b8fa11c50331d2647b8aa7e37935efeb": {
-      "key": "ox-qQsAiHb67Kz3ypxY19uU2_YwVcSjvdbaBVHZJQFY=",
-      "locating": false,
-      "aws-token-encrypted-key": "AWS_TOKEN"
+      "id-token": "...",
+      "refresh-token": "...",
+      "id-token-expires-at": 1746799200.0,
+      "serial-number": "...",
+      "motor-unit-serial": "..."
     }
   }
 }
 ```
 
-1. Move the `key` to the root of the JSON
-2. Restart HA
-3. Try to re-add the integration
-4. If still happens - follow instructions of section #1 (_i._)
+You generally do not need to edit this file by hand — re-running the config flow rewrites it.
 
 ## Lovelace cards.
 
@@ -315,35 +262,11 @@ features:
       - return_home
 ```
 
-### OTP (One-Time Password) Authentication Issues
+### OTP login troubleshooting
 
-NOTE: New users will have an account created using OTP. As yet, we have not been able to reverse engineer the OTP login process. Please see this issue for further information, and a manual workaround to create an account: https://github.com/sh00t2kill/dolphin-robot/issues/199#issuecomment-2481627312
+If you cannot complete the OTP flow:
 
-#### Manual Account Creation Workaround
-
-If you're experiencing OTP authentication issues, you can create a new account directly using the Maytronics API:
-
-```bash
-curl -X POST "https://mbapp18.maytronics.com/api/users/register/" \
-     -H "appkey: 346BDE92-53D1-4829-8A2E-B496014B586C" \
-     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
-     --data-urlencode "email=your-email@example.com" \
-     --data-urlencode "password=your-new-password" \
-     --data-urlencode "firstName=Your" \
-     --data-urlencode "lastName=Name"
-```
-
-**Steps:**
-
-1. Replace the placeholders with your actual information:
-
-   - `your-email@example.com` - Your email address
-   - `your-new-password` - A new password for your account
-   - `Your` - Your first name
-   - `Name` - Your last name
-
-2. Run the curl command in your terminal
-
-3. Use the new credentials in the Home Assistant integration configuration
-
-**Note:** This creates a fresh account that bypasses the OTP requirement. If you use the same email as your existing account, you may not need to re-pair your robot.
+- **No email arrives** — check spam, then retry. If repeated retries fail, Cognito may be rate-limiting; wait a few minutes.
+- **"Invalid or expired login code"** — codes are short-lived. Restart the config flow to receive a fresh one.
+- **"Failed to send login code"** — usually means Cognito does not recognise the email. Confirm you can sign in to the official MyDolphin Plus app with the same address; if not, register the account in the app first.
+- **Repeated failures with a known-good email** — collect debug logs (see [Troubleshooting](#troubleshooting)) and open an issue.

--- a/custom_components/mydolphin_plus/__init__.py
+++ b/custom_components/mydolphin_plus/__init__.py
@@ -7,13 +7,22 @@ import logging
 import sys
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.const import EVENT_HOMEASSISTANT_START, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from .common.consts import DEFAULT_NAME, DOMAIN, PLATFORMS
+from .common.consts import (
+    DEFAULT_NAME,
+    DOMAIN,
+    INITIAL_TOKENS_KEY,
+    PLATFORMS,
+    STORAGE_DATA_ID_TOKEN,
+    STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
+    STORAGE_DATA_MOTOR_UNIT_SERIAL,
+    STORAGE_DATA_REFRESH_TOKEN,
+    STORAGE_DATA_SERIAL_NUMBER,
+)
 from .managers.config_manager import ConfigManager
 from .managers.coordinator import MyDolphinPlusCoordinator
-from .managers.password_manager import PasswordManager
 from .models.exceptions import LoginError
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,16 +33,33 @@ async def async_setup(_hass, _config):
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up a Shinobi Video component."""
+    """Set up a MyDolphin Plus config entry."""
     initialized = False
 
     try:
-        entry_config = {key: entry.data[key] for key in entry.data}
-
-        await PasswordManager.decrypt(hass, entry_config, entry.entry_id)
+        entry_config = dict(entry.data)
+        initial_tokens = entry_config.pop(INITIAL_TOKENS_KEY, None)
 
         config_manager = ConfigManager(hass, entry)
         await config_manager.initialize(entry_config)
+
+        if initial_tokens is not None:
+            await config_manager.update_tokens(
+                initial_tokens.get(STORAGE_DATA_ID_TOKEN),
+                initial_tokens.get(STORAGE_DATA_REFRESH_TOKEN),
+                initial_tokens.get(STORAGE_DATA_ID_TOKEN_EXPIRES_AT),
+            )
+            serial = initial_tokens.get(STORAGE_DATA_SERIAL_NUMBER)
+            if serial:
+                await config_manager.update_serial_number(serial)
+            motor_unit_serial = initial_tokens.get(STORAGE_DATA_MOTOR_UNIT_SERIAL)
+            if motor_unit_serial:
+                await config_manager.update_motor_unit_serial(motor_unit_serial)
+
+            hass.config_entries.async_update_entry(
+                entry,
+                data={CONF_USERNAME: entry_config.get(CONF_USERNAME)},
+            )
 
         is_initialized = config_manager.is_initialized
 
@@ -44,7 +70,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             if hass.is_running:
                 await coordinator.initialize()
-
             else:
                 hass.bus.async_listen_once(
                     EVENT_HOMEASSISTANT_START, coordinator.on_home_assistant_start

--- a/custom_components/mydolphin_plus/common/consts.py
+++ b/custom_components/mydolphin_plus/common/consts.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from homeassistant.components.vacuum import VacuumEntityFeature
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import CONF_USERNAME, Platform
 
 MANUFACTURER = "Maytronics"
 DEFAULT_NAME = "MyDolphin Plus"
@@ -12,7 +12,9 @@ CONFIGURATION_FILE = f"{DOMAIN}.config.json"
 INVALID_TOKEN_SECTION = "https://github.com/sh00t2kill/dolphin-robot#invalid-token"
 
 CONF_TITLE = "title"
-CONF_RESET_PASSWORD = "reset_password"
+CONF_OTP = "otp"
+
+INITIAL_TOKENS_KEY = "__initial_tokens__"
 
 SIGNAL_DEVICE_NEW = f"{DOMAIN}_NEW_DEVICE_SIGNAL"
 SIGNAL_AWS_CLIENT_STATUS = f"{DOMAIN}_AWS_CLIENT_STATUS_SIGNAL"
@@ -128,17 +130,31 @@ WS_RECONNECT_INTERVAL = timedelta(minutes=1)
 
 WS_LAST_UPDATE = "last-update"
 
-BASE_API = "https://mbapp18.maytronics.com/api"
-LOGIN_URL = f"{BASE_API}/users/Login/"
-EMAIL_VALIDATION_URL = f"{BASE_API}/users/isEmailExists/"
-FORGOT_PASSWORD_URL = f"{BASE_API}/users/ForgotPassword/"
-TOKEN_URL = f"{BASE_API}/IOT/getToken_DecryptSN/"
-ROBOT_DETAILS_URL = f"{BASE_API}/serialnumbers/getrobotdetailsbymusn/"
-ROBOT_DETAILS_BY_SN_URL = f"{BASE_API}/serialnumbers/getrobotdetailsbyrobotsn/"
+COGNITO_CLIENT_ID = "4ed12eq01o6n0tl5f0sqmkq2na"
+COGNITO_ENDPOINT = "https://cognito-idp.us-west-2.amazonaws.com/"
+COGNITO_TARGET_PREFIX = "AWSCognitoIdentityProviderService."
+COGNITO_HEADER_TARGET = "X-Amz-Target"
+COGNITO_CONTENT_TYPE = "application/x-amz-json-1.1"
+COGNITO_AUTH_FLOW_CUSTOM = "CUSTOM_AUTH"
+COGNITO_AUTH_FLOW_REFRESH = "REFRESH_TOKEN_AUTH"
+COGNITO_CHALLENGE_NAME = "CUSTOM_CHALLENGE"
 
-API_REQUEST_HEADER_TOKEN = "token"
+APPS_BASE = "https://apps.maytronics.com"
+AUTHENTICATE_USER_URL = f"{APPS_BASE}/mobapi/user/authenticate-user/"
+AWS_STS_TOKEN_URL = f"{APPS_BASE}/mt-sso/aws/getToken/"
+
+APP_KEY = "346BDE92-53D1-4829-8A2E-B496014B586C"
+APP_VERSION = "ios_3.1.7_2"
+
+BEARER_HEADERS_BASE = {
+    "AppKey": APP_KEY,
+    "app_version": APP_VERSION,
+    "Accept": "*/*",
+}
+
+ID_TOKEN_REFRESH_WINDOW_SECONDS = 300
+
 API_REQUEST_SERIAL_EMAIL = "Email"
-API_REQUEST_SERIAL_PASSWORD = "Password"
 API_REQUEST_SERIAL_NUMBER = "Sernum"
 
 API_RESPONSE_DATA = "Data"
@@ -160,8 +176,6 @@ API_TOKEN_FIELDS = [
     API_RESPONSE_DATA_SECRET_ACCESS_KEY,
 ]
 
-BLOCK_SIZE = 16
-
 MQTT_MESSAGE_ENCODING = "utf-8"
 
 AWS_REGION = "eu-west-1"
@@ -169,12 +183,6 @@ AWS_BASE_HOST = f"{AWS_REGION}.amazonaws.com"
 
 AWS_IOT_URL = f"a12rqfdx55bdbv-ats.iot.{AWS_BASE_HOST}"
 AWS_IOT_PORT = 443
-
-LOGIN_HEADERS = {
-    "appkey": "346BDE92-53D1-4829-8A2E-B496014B586C",
-    "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
-    "integration-version": "1.0.19",
-}
 
 CA_FILE_NAME = "AmazonRootCA.pem"
 
@@ -272,8 +280,9 @@ VACUUM_FEATURES = (
 
 STORAGE_DATA_KEY = "key"
 STORAGE_DATA_LOCATING = "locating"
-STORAGE_DATA_AWS_TOKEN = "aws-token"
-STORAGE_DATA_API_TOKEN = "api-token"
+STORAGE_DATA_ID_TOKEN = "id-token"
+STORAGE_DATA_REFRESH_TOKEN = "refresh-token"
+STORAGE_DATA_ID_TOKEN_EXPIRES_AT = "id-token-expires-at"
 STORAGE_DATA_SERIAL_NUMBER = "serial-number"
 STORAGE_DATA_MOTOR_UNIT_SERIAL = "motor-unit-serial"
 
@@ -305,8 +314,9 @@ ERROR_CLEAN_CODES = [0, 255]
 EVENT_ERROR = f"{DOMAIN}_error"
 
 TOKEN_PARAMS = [
-    STORAGE_DATA_AWS_TOKEN,
-    STORAGE_DATA_API_TOKEN,
+    STORAGE_DATA_ID_TOKEN,
+    STORAGE_DATA_REFRESH_TOKEN,
+    STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
     STORAGE_DATA_SERIAL_NUMBER,
     STORAGE_DATA_MOTOR_UNIT_SERIAL,
 ]
@@ -317,7 +327,6 @@ TO_REDACT = [
     API_RESPONSE_DATA_SECRET_ACCESS_KEY,
     DYNAMIC_CONTENT_SERIAL_NUMBER,
     CONF_USERNAME,
-    CONF_PASSWORD,
 ]
 
 TO_REDACT.extend(TOKEN_PARAMS)

--- a/custom_components/mydolphin_plus/config_flow.py
+++ b/custom_components/mydolphin_plus/config_flow.py
@@ -30,10 +30,14 @@ class DomainFlowHandler(config_entries.ConfigFlow):
         return DomainOptionsFlowHandler(config_entry)
 
     async def async_step_user(self, user_input=None):
-        """Handle a flow start."""
+        """Handle a flow start (email step)."""
         flow_manager = IntegrationFlowManager(self.hass, self)
+        return await flow_manager.async_step_user(user_input)
 
-        return await flow_manager.async_step(user_input)
+    async def async_step_otp(self, user_input=None):
+        """Handle the OTP confirmation step."""
+        flow_manager = IntegrationFlowManager(self.hass, self)
+        return await flow_manager.async_step_otp(user_input)
 
 
 class DomainOptionsFlowHandler(config_entries.OptionsFlow):
@@ -44,11 +48,17 @@ class DomainOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: ConfigEntry):
         """Initialize domain options flow."""
         super().__init__()
-
         self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
-        """Manage the domain options."""
-        flow_manager = IntegrationFlowManager(self.hass, self, self._config_entry)
+        """Manage the domain options (re-trigger OTP login)."""
+        flow_manager = IntegrationFlowManager(
+            self.hass, self, self._config_entry
+        )
+        return await flow_manager.async_step_user(user_input)
 
-        return await flow_manager.async_step(user_input)
+    async def async_step_otp(self, user_input=None):
+        flow_manager = IntegrationFlowManager(
+            self.hass, self, self._config_entry
+        )
+        return await flow_manager.async_step_otp(user_input)

--- a/custom_components/mydolphin_plus/managers/config_manager.py
+++ b/custom_components/mydolphin_plus/managers/config_manager.py
@@ -6,7 +6,7 @@ import sys
 from cryptography.fernet import InvalidToken
 
 from homeassistant.config_entries import STORAGE_VERSION, ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import CONF_NAME, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import translation
 from homeassistant.helpers.entity import DeviceInfo
@@ -23,10 +23,11 @@ from ..common.consts import (
     DEFAULT_NAME,
     DOMAIN,
     INVALID_TOKEN_SECTION,
-    STORAGE_DATA_API_TOKEN,
-    STORAGE_DATA_AWS_TOKEN,
+    STORAGE_DATA_ID_TOKEN,
+    STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
     STORAGE_DATA_LOCATING,
     STORAGE_DATA_MOTOR_UNIT_SERIAL,
+    STORAGE_DATA_REFRESH_TOKEN,
     STORAGE_DATA_SERIAL_NUMBER,
     TOKEN_PARAMS,
 )
@@ -101,16 +102,16 @@ class ConfigManager:
         return is_locating
 
     @property
-    def api_token(self) -> str | None:
-        api_token = self._data.get(STORAGE_DATA_API_TOKEN)
-
-        return api_token
+    def id_token(self) -> str | None:
+        return self._data.get(STORAGE_DATA_ID_TOKEN)
 
     @property
-    def aws_token(self) -> str | None:
-        aws_token = self._data.get(STORAGE_DATA_AWS_TOKEN)
+    def refresh_token(self) -> str | None:
+        return self._data.get(STORAGE_DATA_REFRESH_TOKEN)
 
-        return aws_token
+    @property
+    def id_token_expires_at(self) -> float | None:
+        return self._data.get(STORAGE_DATA_ID_TOKEN_EXPIRES_AT)
 
     @property
     def serial_number(self) -> str | None:
@@ -237,14 +238,21 @@ class ConfigManager:
 
         await self._save()
 
-    async def update_login_details(self, api_token: str, serial_number: str):
-        self._data[STORAGE_DATA_API_TOKEN] = api_token
-        self._data[STORAGE_DATA_SERIAL_NUMBER] = serial_number
+    async def update_tokens(
+        self,
+        id_token: str,
+        refresh_token: str | None,
+        expires_at: float,
+    ):
+        self._data[STORAGE_DATA_ID_TOKEN] = id_token
+        if refresh_token is not None:
+            self._data[STORAGE_DATA_REFRESH_TOKEN] = refresh_token
+        self._data[STORAGE_DATA_ID_TOKEN_EXPIRES_AT] = expires_at
 
         await self._save()
 
-    async def update_aws_token(self, aws_token: str | None):
-        self._data[STORAGE_DATA_AWS_TOKEN] = aws_token
+    async def update_serial_number(self, serial_number: str):
+        self._data[STORAGE_DATA_SERIAL_NUMBER] = serial_number
 
         await self._save()
 
@@ -353,10 +361,9 @@ class ConfigManager:
             for key in self._data:
                 stored_value = entry_data.get(key)
 
-                if key in [CONF_PASSWORD, CONF_USERNAME]:
-                    entry_data.pop(CONF_USERNAME)
-
+                if key == CONF_USERNAME:
                     if stored_value is not None:
+                        entry_data.pop(CONF_USERNAME)
                         should_save = True
 
                 else:

--- a/custom_components/mydolphin_plus/managers/flow_manager.py
+++ b/custom_components/mydolphin_plus/managers/flow_manager.py
@@ -1,25 +1,37 @@
 """Config flow to configure."""
 from __future__ import annotations
 
-from copy import copy
 import logging
-from typing import Any
-
-from cryptography.fernet import InvalidToken
+import time
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowHandler
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from ..common.connectivity_status import ConnectivityStatus
-from ..common.consts import CONF_RESET_PASSWORD, CONF_TITLE, DEFAULT_NAME
-from ..models.config_data import DATA_KEYS, ConfigData
+from ..common.consts import (
+    CONF_OTP,
+    CONF_TITLE,
+    DEFAULT_NAME,
+    INITIAL_TOKENS_KEY,
+    STORAGE_DATA_ID_TOKEN,
+    STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
+    STORAGE_DATA_MOTOR_UNIT_SERIAL,
+    STORAGE_DATA_REFRESH_TOKEN,
+    STORAGE_DATA_SERIAL_NUMBER,
+)
+from ..models.config_data import ConfigData
 from ..models.exceptions import LoginError
-from .config_manager import ConfigManager
-from .password_manager import PasswordManager
-from .rest_api import RestAPI
+from .rest_api import (
+    cognito_initiate_auth,
+    cognito_respond_otp,
+    fetch_user_profile,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+_FLOW_STATE_ATTR = "_mydolphin_state"
 
 
 class IntegrationFlowManager:
@@ -28,8 +40,6 @@ class IntegrationFlowManager:
 
     _flow_handler: FlowHandler
     _flow_id: str
-
-    _config_manager: ConfigManager
 
     def __init__(
         self,
@@ -41,107 +51,114 @@ class IntegrationFlowManager:
         self._flow_handler = flow_handler
         self._entry = entry
         self._flow_id = "user" if entry is None else "init"
-        self._config_manager = ConfigManager(self._hass, None)
 
     async def async_step(self, user_input: dict | None = None):
-        """Manage the domain options."""
-        _LOGGER.info(f"Config flow started, Step: {self._flow_id}")
+        return await self.async_step_user(user_input)
 
-        form_errors = None
+    async def async_step_user(self, user_input: dict | None = None):
+        _LOGGER.info(f"Config flow user step, has_input={user_input is not None}")
 
         if user_input is None:
-            if self._entry is None:
-                user_input = {}
+            defaults = (
+                {CONF_TITLE: self._entry.title, CONF_USERNAME: self._entry.data.get(CONF_USERNAME)}
+                if self._entry is not None
+                else {}
+            )
+            return self._show_user_form(defaults)
 
-            else:
-                user_input = {key: self._entry.data[key] for key in self._entry.data}
-                user_input[CONF_TITLE] = self._entry.title
+        email = (user_input.get(CONF_USERNAME) or "").strip().lower()
+        title = user_input.get(CONF_TITLE, DEFAULT_NAME)
 
-                await PasswordManager.decrypt(
-                    self._hass, user_input, self._entry.entry_id
-                )
+        if not email:
+            return self._show_user_form(user_input, errors={"base": "invalid_account"})
 
-        else:
-            error_key: str | None = None
+        session = async_get_clientsession(self._hass)
+        try:
+            init = await cognito_initiate_auth(session, email)
+        except LoginError as ex:
+            _LOGGER.warning(f"Cognito InitiateAuth failed: {ex}")
+            return self._show_user_form(
+                user_input, errors={"base": "otp_send_failed"}
+            )
 
-            try:
-                await self._config_manager.initialize(user_input)
+        setattr(
+            self._flow_handler,
+            _FLOW_STATE_ATTR,
+            {
+                "title": title,
+                "email": email,
+                "cognito_session": init["Session"],
+            },
+        )
 
-                api = RestAPI(self._hass, self._config_manager)
+        return self._show_otp_form()
 
-                reset_password_flow = user_input.get(CONF_RESET_PASSWORD, False)
+    async def async_step_otp(self, user_input: dict | None = None):
+        state = getattr(self._flow_handler, _FLOW_STATE_ATTR, None)
+        if state is None:
+            return await self.async_step_user(None)
 
-                if reset_password_flow:
-                    await api.reset_password()
-                    user_input = {}
+        if user_input is None:
+            return self._show_otp_form()
 
-                else:
-                    await api.validate()
+        code = (user_input.get(CONF_OTP) or "").strip()
+        if not code:
+            return self._show_otp_form(errors={"base": "invalid_otp"})
 
-                    if api.status == ConnectivityStatus.TEMPORARY_CONNECTED:
-                        _LOGGER.debug("User inputs are valid")
+        session = async_get_clientsession(self._hass)
+        try:
+            auth = await cognito_respond_otp(
+                session, state["email"], state["cognito_session"], code
+            )
+            profile = await fetch_user_profile(session, auth["IdToken"])
+        except LoginError as ex:
+            _LOGGER.warning(f"OTP exchange failed: {ex}")
+            return self._show_otp_form(errors={"base": "invalid_otp"})
 
-                        if self._entry is None:
-                            data = copy(user_input)
+        expires_at = time.time() + int(auth.get("ExpiresIn", 3600))
+        initial_tokens = {
+            STORAGE_DATA_ID_TOKEN: auth["IdToken"],
+            STORAGE_DATA_REFRESH_TOKEN: auth.get("RefreshToken"),
+            STORAGE_DATA_ID_TOKEN_EXPIRES_AT: expires_at,
+            STORAGE_DATA_SERIAL_NUMBER: profile.get("Sernum"),
+            STORAGE_DATA_MOTOR_UNIT_SERIAL: profile.get("eSERNUM"),
+        }
 
-                        else:
-                            data = await self.remap_entry_data(user_input)
+        try:
+            delattr(self._flow_handler, _FLOW_STATE_ATTR)
+        except AttributeError:
+            pass
 
-                        await PasswordManager.encrypt(self._hass, data)
+        if self._entry is not None:
+            self._hass.config_entries.async_update_entry(
+                self._entry,
+                title=state["title"],
+                data={
+                    CONF_USERNAME: state["email"],
+                    INITIAL_TOKENS_KEY: initial_tokens,
+                },
+            )
+            self._hass.config_entries.async_schedule_reload(self._entry.entry_id)
+            return self._flow_handler.async_create_entry(title="", data={})
 
-                        title = data.get(CONF_TITLE, DEFAULT_NAME)
+        return self._flow_handler.async_create_entry(
+            title=state["title"],
+            data={
+                CONF_USERNAME: state["email"],
+                INITIAL_TOKENS_KEY: initial_tokens,
+            },
+        )
 
-                        new_user_data = {
-                            key: data[key] for key in data if key in DATA_KEYS
-                        }
-
-                        return self._flow_handler.async_create_entry(
-                            title=title, data=new_user_data
-                        )
-
-                    else:
-                        error_key = ConnectivityStatus.get_ha_error(api.status)
-
-            except LoginError:
-                error_key = "invalid_credentials"
-
-            except InvalidToken:
-                error_key = "corrupted_encryption_key"
-
-            if error_key is not None:
-                form_errors = {"base": error_key}
-
-                _LOGGER.warning(f"Failed to create integration, Error Key: {error_key}")
-
-        schema = ConfigData.default_schema(user_input)
-
+    def _show_user_form(self, user_input: dict | None = None, errors=None):
         return self._flow_handler.async_show_form(
-            step_id=self._flow_id, data_schema=schema, errors=form_errors
+            step_id=self._flow_id,
+            data_schema=ConfigData.default_schema(user_input),
+            errors=errors,
         )
 
-    async def remap_entry_data(self, options: dict[str, Any]) -> dict[str, Any]:
-        entry = self._entry
-        entry_data = entry.data
-
-        title = options.get(CONF_TITLE, DEFAULT_NAME)
-
-        config_data = {
-            key: options.get(key, entry_data.get(key))
-            for key in options
-            if key in DATA_KEYS
-        }
-
-        options_excluded_keys = [CONF_TITLE, CONF_RESET_PASSWORD]
-        options_excluded_keys.extend(DATA_KEYS)
-
-        config_options = {
-            key: options[key] for key in options if key not in options_excluded_keys
-        }
-
-        await PasswordManager.encrypt(self._hass, config_data)
-
-        self._hass.config_entries.async_update_entry(
-            entry, data=config_data, title=title
+    def _show_otp_form(self, errors=None):
+        return self._flow_handler.async_show_form(
+            step_id="otp",
+            data_schema=ConfigData.otp_schema(),
+            errors=errors,
         )
-
-        return config_options

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from asyncio import sleep
-from base64 import b64encode
-import hashlib
+import json
 import logging
-import secrets
 import sys
+import time
 from typing import Any
 
 from aiohttp import ClientResponseError, ClientSession
-from aiohttp.hdrs import METH_GET, METH_POST
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -19,88 +14,201 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 
 from ..common.connectivity_status import ConnectivityStatus
 from ..common.consts import (
-    API_REQUEST_HEADER_TOKEN,
-    API_REQUEST_SERIAL_EMAIL,
-    API_REQUEST_SERIAL_NUMBER,
-    API_REQUEST_SERIAL_PASSWORD,
     API_RESPONSE_ALERT,
     API_RESPONSE_DATA,
-    API_RESPONSE_IS_EMAIL_EXISTS,
-    API_RESPONSE_STATUS,
-    API_RESPONSE_STATUS_FAILURE,
-    API_RESPONSE_STATUS_SUCCESS,
     API_RESPONSE_UNIT_SERIAL_NUMBER,
     API_TOKEN_FIELDS,
-    BLOCK_SIZE,
+    AUTHENTICATE_USER_URL,
+    AWS_STS_TOKEN_URL,
+    BEARER_HEADERS_BASE,
+    COGNITO_AUTH_FLOW_CUSTOM,
+    COGNITO_AUTH_FLOW_REFRESH,
+    COGNITO_CHALLENGE_NAME,
+    COGNITO_CLIENT_ID,
+    COGNITO_CONTENT_TYPE,
+    COGNITO_ENDPOINT,
+    COGNITO_HEADER_TARGET,
+    COGNITO_TARGET_PREFIX,
     DATA_ROBOT_DETAILS,
-    DEFAULT_NAME,
-    EMAIL_VALIDATION_URL,
-    FORGOT_PASSWORD_URL,
-    LOGIN_HEADERS,
-    LOGIN_URL,
-    ROBOT_DETAILS_BY_SN_URL,
-    ROBOT_DETAILS_URL,
+    ID_TOKEN_REFRESH_WINDOW_SECONDS,
     SIGNAL_API_STATUS,
     SIGNAL_DEVICE_NEW,
-    TOKEN_URL,
 )
 from ..models.config_data import ConfigData
+from ..models.exceptions import LoginError
 from .config_manager import ConfigManager
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _bearer_headers(id_token: str, extra: dict | None = None) -> dict:
+    headers = {
+        "Authorization": f"Bearer {id_token}",
+        **BEARER_HEADERS_BASE,
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+async def _cognito_call(session: ClientSession, target: str, body: dict) -> dict:
+    headers = {
+        "Content-Type": COGNITO_CONTENT_TYPE,
+        COGNITO_HEADER_TARGET: f"{COGNITO_TARGET_PREFIX}{target}",
+    }
+    try:
+        async with session.post(
+            COGNITO_ENDPOINT, headers=headers, data=json.dumps(body)
+        ) as response:
+            text = await response.text()
+            if response.status >= 400:
+                _LOGGER.debug(
+                    f"Cognito {target} failed, Status: {response.status}, Body: {text}"
+                )
+                raise LoginError(f"Cognito {target} returned {response.status}")
+            return json.loads(text)
+    except LoginError:
+        raise
+    except Exception as ex:
+        _LOGGER.debug(f"Cognito {target} request failed, Error: {ex}")
+        raise LoginError(f"Cognito {target} request failed: {ex}") from ex
+
+
+async def cognito_initiate_auth(session: ClientSession, email: str) -> dict:
+    response = await _cognito_call(
+        session,
+        "InitiateAuth",
+        {
+            "AuthFlow": COGNITO_AUTH_FLOW_CUSTOM,
+            "ClientId": COGNITO_CLIENT_ID,
+            "AuthParameters": {"USERNAME": email},
+            "ClientMetadata": {},
+        },
+    )
+    if response.get("ChallengeName") != COGNITO_CHALLENGE_NAME:
+        raise LoginError(
+            f"Unexpected Cognito challenge: {response.get('ChallengeName')}"
+        )
+    return response
+
+
+async def cognito_respond_otp(
+    session: ClientSession, email: str, cognito_session: str, code: str
+) -> dict:
+    response = await _cognito_call(
+        session,
+        "RespondToAuthChallenge",
+        {
+            "ChallengeName": COGNITO_CHALLENGE_NAME,
+            "ClientId": COGNITO_CLIENT_ID,
+            "Session": cognito_session,
+            "ChallengeResponses": {"USERNAME": email, "ANSWER": code},
+            "ClientMetadata": {},
+        },
+    )
+    auth = response.get("AuthenticationResult")
+    if not auth or "IdToken" not in auth:
+        raise LoginError("OTP rejected by Cognito")
+    return auth
+
+
+async def cognito_refresh(session: ClientSession, refresh_token: str) -> dict:
+    response = await _cognito_call(
+        session,
+        "InitiateAuth",
+        {
+            "AuthFlow": COGNITO_AUTH_FLOW_REFRESH,
+            "ClientId": COGNITO_CLIENT_ID,
+            "AuthParameters": {"REFRESH_TOKEN": refresh_token},
+            "ClientMetadata": {},
+        },
+    )
+    auth = response.get("AuthenticationResult")
+    if not auth or "IdToken" not in auth:
+        raise LoginError("Refresh token rejected by Cognito")
+    return auth
+
+
+async def fetch_user_profile(session: ClientSession, id_token: str) -> dict:
+    headers = _bearer_headers(
+        id_token,
+        {"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        async with session.post(
+            AUTHENTICATE_USER_URL, headers=headers, data=""
+        ) as response:
+            response.raise_for_status()
+            payload = await response.json()
+    except ClientResponseError as ex:
+        raise LoginError(f"authenticate-user failed: HTTP {ex.status}") from ex
+    except Exception as ex:
+        raise LoginError(f"authenticate-user request failed: {ex}") from ex
+
+    data = payload.get(API_RESPONSE_DATA) or {}
+    if not data:
+        raise LoginError(
+            f"authenticate-user returned empty data, Alert: {payload.get(API_RESPONSE_ALERT)}"
+        )
+    return data
+
+
+async def fetch_aws_credentials(session: ClientSession, id_token: str) -> dict:
+    headers = _bearer_headers(id_token)
+    try:
+        async with session.get(AWS_STS_TOKEN_URL, headers=headers) as response:
+            response.raise_for_status()
+            payload = await response.json()
+    except ClientResponseError as ex:
+        raise LoginError(f"getToken failed: HTTP {ex.status}") from ex
+    except Exception as ex:
+        raise LoginError(f"getToken request failed: {ex}") from ex
+
+    data = payload.get(API_RESPONSE_DATA) or {}
+    if not data.get("AccessKeyId"):
+        raise LoginError(
+            f"getToken returned no credentials, Alert: {payload.get(API_RESPONSE_ALERT)}"
+        )
+    return data
 
 
 class RestAPI:
     data: dict
 
     _hass: HomeAssistant | None
-    _base_url: str | None
     _status: ConnectivityStatus | None
     _session: ClientSession | None
     _config_manager: ConfigManager
-
     _device_loaded: bool
 
     def __init__(self, hass: HomeAssistant | None, config_manager: ConfigManager):
         try:
             self._hass = hass
-
             self.data = {}
-
             self._config_manager = config_manager
-
             self._status = None
-
             self._session = None
             self._device_loaded = False
-
             self._local_async_dispatcher_send = None
 
         except Exception as ex:
             exc_type, exc_obj, tb = sys.exc_info()
             line_number = tb.tb_lineno
-
             _LOGGER.error(
                 f"Failed to load MyDolphin Plus API, error: {ex}, line: {line_number}"
             )
 
     @property
     def is_connected(self):
-        result = self._session is not None
-
-        return result
+        return self._session is not None
 
     @property
     def config_data(self) -> ConfigData:
-        result = self._config_manager.config_data
-
-        return result
+        return self._config_manager.config_data
 
     @property
     def status(self) -> str | None:
-        status = self._status
-
-        return status
+        return self._status
 
     @property
     def _is_home_assistant(self):
@@ -108,504 +216,162 @@ class RestAPI:
 
     async def initialize(self):
         _LOGGER.info("Initializing MyDolphin API")
-
         await self._initialize_session()
-
         await self._login()
 
     async def terminate(self):
         if self._session is not None:
             await self._session.close()
-
             self._set_status(ConnectivityStatus.DISCONNECTED, "terminate requested")
 
     async def _initialize_session(self):
         try:
             if self._is_home_assistant:
                 self._session = async_create_clientsession(hass=self._hass)
-
             else:
                 self._session = ClientSession()
 
         except Exception as ex:
             exc_type, exc_obj, tb = sys.exc_info()
             line_number = tb.tb_lineno
-
             message = (
                 f"Failed to initialize session, Error: {str(ex)}, Line: {line_number}"
             )
-
             self._set_status(ConnectivityStatus.FAILED, message)
-
-    async def validate(self):
-        await self._initialize_session()
-        await self._service_login()
-
-    async def _async_post(self, url, headers: dict, request_data: str | dict | None):
-        result = None
-
-        try:
-            async with self._session.post(
-                url, headers=headers, data=request_data, ssl=False
-            ) as response:
-                _LOGGER.debug(f"Status of {url}: {response.status}")
-
-                response.raise_for_status()
-
-                result = await response.json()
-
-                _LOGGER.debug(
-                    f"POST request [{url}] completed successfully, Result: {result}"
-                )
-
-        except ClientResponseError as crex:
-            await self._handle_client_error(url, METH_POST, crex)
-
-        except TimeoutError:
-            self._handle_server_timeout(url, METH_POST)
-
-        except Exception as ex:
-            self._handle_general_request_failure(url, METH_POST, ex)
-
-        return result
-
-    async def _async_get(self, url, headers: dict):
-        result = None
-
-        try:
-            async with self._session.get(url, headers=headers, ssl=False) as response:
-                _LOGGER.debug(f"Status of {url}: {response.status}")
-
-                response.raise_for_status()
-
-                result = await response.json()
-
-                _LOGGER.debug(
-                    f"GET request [{url}] completed successfully, Result: {result}"
-                )
-
-        except ClientResponseError as crex:
-            await self._handle_client_error(url, METH_GET, crex)
-
-        except TimeoutError:
-            self._handle_server_timeout(url, METH_GET)
-
-        except Exception as ex:
-            self._handle_general_request_failure(url, METH_GET, ex)
-
-        return result
 
     async def update(self):
-        if self._status == ConnectivityStatus.CONNECTED:
-            _LOGGER.debug("Connected. Refresh details")
-            await self._load_details()
-
-            if not self._device_loaded:
-                self._device_loaded = True
-
-                self._async_dispatcher_send(
-                    SIGNAL_DEVICE_NEW, self._config_manager.entry_id
-                )
-
-            _LOGGER.debug(f"API Data updated: {self.data}")
-
-    async def _clean_login_details(self):
-        await self._config_manager.reset_login_details()
-
-    async def _login(self):
-        if self._config_manager.api_token is None:
-            await self._service_login()
-
-        else:
-            self._set_status(
-                ConnectivityStatus.TEMPORARY_CONNECTED, "API Token available"
-            )
-
-        if self._status == ConnectivityStatus.TEMPORARY_CONNECTED:
-            await self._generate_aws_token()
-
-        elif self._status in [
-            ConnectivityStatus.INVALID_CREDENTIALS,
-            ConnectivityStatus.INVALID_ACCOUNT,
-        ]:
-            return
-
-        else:
-            self._set_status(ConnectivityStatus.FAILED, "general failure of login")
-
-    async def reset_password(self):
-        _LOGGER.debug("Starting reset password process")
-
-        if self._session is None:
-            await self._initialize_session()
-
-        is_valid_email = await self._email_validation()
-
-        if is_valid_email:
-            username = self.config_data.username
-
-            request_data = f"{API_REQUEST_SERIAL_EMAIL}={username}"
-
-            payload = await self._async_post(
-                FORGOT_PASSWORD_URL, LOGIN_HEADERS, request_data
-            )
-
-            if payload is None:
-                _LOGGER.error("Empty response of reset password")
-
-            else:
-                data = payload.get(API_RESPONSE_DATA)
-
-                if data is None:
-                    _LOGGER.error("Empty response payload of reset password")
-
-                else:
-                    _LOGGER.info(f"Reset password response: {data}")
-
-    async def _email_validation(self) -> bool:
-        _LOGGER.debug("Validating account email")
-
-        if self._status != ConnectivityStatus.INVALID_ACCOUNT:
-            username = self.config_data.username
-
-            request_data = f"{API_REQUEST_SERIAL_EMAIL}={username}"
-
-            payload = await self._async_post(
-                EMAIL_VALIDATION_URL, LOGIN_HEADERS, request_data
-            )
-
-            if payload is None:
-                self._set_status(
-                    ConnectivityStatus.INVALID_ACCOUNT,
-                    "empty response of email validation",
-                )
-
-            else:
-                data = payload.get(API_RESPONSE_DATA)
-
-                if data is None:
-                    self._set_status(
-                        ConnectivityStatus.INVALID_ACCOUNT,
-                        "empty response payload of email validation",
-                    )
-
-                else:
-                    status = data.get(API_RESPONSE_IS_EMAIL_EXISTS, False)
-
-                    if not status:
-                        self._set_status(
-                            ConnectivityStatus.INVALID_ACCOUNT,
-                            f"account [{username}] is not valid",
-                        )
-
-        is_valid_account = self._status != ConnectivityStatus.INVALID_ACCOUNT
-
-        return is_valid_account
-
-    async def _service_login(self):
-        try:
-            is_valid_account = await self._email_validation()
-
-            if not is_valid_account:
-                return
-
-            self._set_status(ConnectivityStatus.CONNECTING)
-
-            username = self.config_data.username
-            password = self.config_data.password
-
-            request_data = f"{API_REQUEST_SERIAL_EMAIL}={username}&{API_REQUEST_SERIAL_PASSWORD}={password}"
-
-            payload = await self._async_post(LOGIN_URL, LOGIN_HEADERS, request_data)
-
-            if payload is None:
-                self._set_status(ConnectivityStatus.FAILED, "empty response of login")
-
-            else:
-                data = payload.get(API_RESPONSE_DATA)
-
-                if data is None:
-                    self._set_status(
-                        ConnectivityStatus.INVALID_CREDENTIALS,
-                        "empty response payload of login",
-                    )
-
-                elif isinstance(data, str):
-                    _LOGGER.error(f"Invalid response payload of login: {data}")
-
-                    self._set_status(
-                        ConnectivityStatus.INVALID_CREDENTIALS,
-                        "invalid response payload of login",
-                    )
-
-                else:
-                    _LOGGER.info(f"Logged in to user {username}")
-
-                    serial_number = data.get(API_REQUEST_SERIAL_NUMBER)
-                    api_token = data.get(API_REQUEST_HEADER_TOKEN)
-
-                    await self._config_manager.update_login_details(
-                        api_token, serial_number
-                    )
-
-                    await self._set_actual_motor_unit_serial()
-
-        except Exception as ex:
-            exc_type, exc_obj, tb = sys.exc_info()
-            line_number = tb.tb_lineno
-
-            message = f"Failed to login into {DEFAULT_NAME} service, Error: {str(ex)}, Line: {line_number}"
-
-            self._set_status(ConnectivityStatus.FAILED, message)
-
-    async def _set_actual_motor_unit_serial(self):
-        try:
-            headers = {API_REQUEST_HEADER_TOKEN: self._config_manager.api_token}
-
-            for key in LOGIN_HEADERS:
-                headers[key] = LOGIN_HEADERS[key]
-
-            request_data = (
-                f"{API_REQUEST_SERIAL_NUMBER}={self._config_manager.serial_number}"
-            )
-
-            payload = await self._async_post(
-                ROBOT_DETAILS_BY_SN_URL, headers, request_data
-            )
-
-            if payload is None:
-                payload = {}
-
-            data: dict = payload.get(API_RESPONSE_DATA, {})
-
-            if data is not None:
-                message = f"Successfully retrieved details for device {self._config_manager.serial_number}"
-
-                motor_unit_serial = data.get(API_RESPONSE_UNIT_SERIAL_NUMBER)
-
-                await self._config_manager.update_motor_unit_serial(motor_unit_serial)
-
-                self._set_status(ConnectivityStatus.TEMPORARY_CONNECTED, message)
-
-        except Exception as ex:
-            exc_type, exc_obj, tb = sys.exc_info()
-            line_number = tb.tb_lineno
-
-            message = f"Failed to login into {DEFAULT_NAME} service, Error: {str(ex)}, Line: {line_number}"
-
-            self._set_status(ConnectivityStatus.FAILED, message)
-
-    async def _generate_aws_token(self):
-        try:
-            headers = {API_REQUEST_HEADER_TOKEN: self._config_manager.api_token}
-
-            for key in LOGIN_HEADERS:
-                headers[key] = LOGIN_HEADERS[key]
-
-            aws_token = self._config_manager.aws_token
-
-            if aws_token is None:
-                aws_token = await self._get_aws_token()
-
-                await self._config_manager.update_aws_token(aws_token)
-
-            request_data = f"{API_REQUEST_SERIAL_NUMBER}={aws_token}"
-
-            payload = await self._async_post(TOKEN_URL, headers, request_data)
-
-            if self._status == ConnectivityStatus.TEMPORARY_CONNECTED:
-                data = payload.get(API_RESPONSE_DATA, {})
-                alert = payload.get(API_RESPONSE_ALERT, {})
-                status = payload.get(API_RESPONSE_STATUS, API_RESPONSE_STATUS_FAILURE)
-
-                if status == API_RESPONSE_STATUS_SUCCESS:
-                    for field in API_TOKEN_FIELDS:
-                        self.data[field] = data.get(field)
-
-                    self._set_status(ConnectivityStatus.CONNECTED)
-
-                else:
-                    message = f"Failed to retrieve AWS token, Error: {alert}"
-
-                    self._set_status(ConnectivityStatus.FAILED, message)
-
-                    await self._config_manager.update_aws_token(None)
-
-        except Exception as ex:
-            exc_type, exc_obj, tb = sys.exc_info()
-            line_number = tb.tb_lineno
-
-            message = f"Failed to retrieve AWS token from service, Error: {str(ex)}, Line: {line_number}"
-
-            self._set_status(ConnectivityStatus.FAILED, message)
-
-    async def _load_details(self):
         if self._status != ConnectivityStatus.CONNECTED:
             return
 
-        try:
-            headers = {API_REQUEST_HEADER_TOKEN: self._config_manager.api_token}
+        _LOGGER.debug("Connected. Refresh details")
 
-            for key in LOGIN_HEADERS:
-                headers[key] = LOGIN_HEADERS[key]
+        if not await self._ensure_id_token_valid():
+            return
 
-            request_data = (
-                f"{API_REQUEST_SERIAL_NUMBER}={self._config_manager.motor_unit_serial}"
+        if not await self._authenticate_user():
+            return
+
+        if not self._device_loaded:
+            self._device_loaded = True
+            self._async_dispatcher_send(
+                SIGNAL_DEVICE_NEW, self._config_manager.entry_id
             )
 
-            payload = await self._async_post(ROBOT_DETAILS_URL, headers, request_data)
+        _LOGGER.debug(f"API Data updated: {self.data}")
 
-            if payload is not None:
-                response_status = payload.get(
-                    API_RESPONSE_STATUS, API_RESPONSE_STATUS_FAILURE
-                )
-                alert = payload.get(API_RESPONSE_STATUS, API_RESPONSE_ALERT)
-
-                if response_status == API_RESPONSE_STATUS_SUCCESS:
-                    data = payload.get(API_RESPONSE_DATA, {})
-
-                    for key in DATA_ROBOT_DETAILS:
-                        new_key = DATA_ROBOT_DETAILS.get(key)
-
-                        self.data[new_key] = data.get(key)
-
-                else:
-                    _LOGGER.error(f"Failed to reload details, Error: {alert}")
-
-        except Exception as ex:
-            exc_type, exc_obj, tb = sys.exc_info()
-            line_number = tb.tb_lineno
-
-            _LOGGER.error(
-                f"Failed to retrieve Robot Details, Error: {str(ex)}, Line: {line_number}"
+    async def _login(self):
+        if self._config_manager.refresh_token is None:
+            self._set_status(
+                ConnectivityStatus.EXPIRED_TOKEN,
+                "no refresh token stored — remove and re-add the integration",
             )
+            return
 
-    async def _get_aws_token(self) -> str | None:
-        _LOGGER.debug(
-            f"ENCRYPT: Motor Unit Serial: {self._config_manager.motor_unit_serial}"
+        if not await self._ensure_id_token_valid():
+            return
+
+        if not await self._authenticate_user():
+            return
+
+        self._set_status(
+            ConnectivityStatus.TEMPORARY_CONNECTED,
+            f"profile loaded for {self._config_manager.serial_number}",
         )
 
-        for i in range(0, 10):
-            backend = default_backend()
-            iv = secrets.token_bytes(BLOCK_SIZE)
-            mode = modes.CBC(iv)
-            aes_key = self._get_aes_key()
+        await self._get_aws_credentials()
 
-            aes = algorithms.AES(aes_key)
-            cipher = Cipher(aes, mode, backend=backend)
+    async def _ensure_id_token_valid(self) -> bool:
+        expires_at = self._config_manager.id_token_expires_at or 0
+        id_token = self._config_manager.id_token
+        now = time.time()
 
-            encryptor = cipher.encryptor()
+        if id_token and (expires_at - now) > ID_TOKEN_REFRESH_WINDOW_SECONDS:
+            return True
 
-            data = self._pad(self._config_manager.motor_unit_serial).encode()
-            ct = encryptor.update(data) + encryptor.finalize()
+        refresh_token = self._config_manager.refresh_token
+        if not refresh_token:
+            self._set_status(
+                ConnectivityStatus.EXPIRED_TOKEN,
+                "no refresh token available — remove and re-add the integration",
+            )
+            return False
 
-            result_b64 = iv + ct
+        try:
+            auth = await cognito_refresh(self._session, refresh_token)
+        except LoginError as ex:
+            self._set_status(
+                ConnectivityStatus.EXPIRED_TOKEN,
+                f"refresh failed ({ex}) — remove and re-add the integration",
+            )
+            return False
 
-            result = b64encode(result_b64).decode()
+        new_expires = time.time() + int(auth.get("ExpiresIn", 3600))
+        await self._config_manager.update_tokens(
+            auth["IdToken"],
+            auth.get("RefreshToken"),
+            new_expires,
+        )
+        _LOGGER.debug("Refreshed Cognito IdToken")
+        return True
 
-            if "+" not in result:
-                return result
+    async def _authenticate_user(self) -> bool:
+        try:
+            data = await fetch_user_profile(
+                self._session, self._config_manager.id_token
+            )
+        except LoginError as ex:
+            self._set_status(ConnectivityStatus.FAILED, f"authenticate-user: {ex}")
+            return False
 
-            await sleep(0.5)
+        serial_number = data.get("Sernum")
+        motor_unit_serial = data.get(API_RESPONSE_UNIT_SERIAL_NUMBER)
 
-        raise ValueError("Invalid AWS Token generated")
+        if serial_number and serial_number != self._config_manager.serial_number:
+            await self._config_manager.update_serial_number(serial_number)
 
-    @staticmethod
-    def _pad(text) -> str:
-        text_length = len(text)
-        amount_to_pad = BLOCK_SIZE - (text_length % BLOCK_SIZE)
+        if (
+            motor_unit_serial
+            and motor_unit_serial != self._config_manager.motor_unit_serial
+        ):
+            await self._config_manager.update_motor_unit_serial(motor_unit_serial)
 
-        if amount_to_pad == 0:
-            amount_to_pad = BLOCK_SIZE
+        for key, mapped in DATA_ROBOT_DETAILS.items():
+            if key in data:
+                self.data[mapped] = data.get(key)
 
-        pad = chr(amount_to_pad)
+        return True
 
-        result = text + pad * amount_to_pad
+    async def _get_aws_credentials(self):
+        try:
+            data = await fetch_aws_credentials(
+                self._session, self._config_manager.id_token
+            )
+        except LoginError as ex:
+            self._set_status(ConnectivityStatus.FAILED, f"getToken: {ex}")
+            return
 
-        return result
+        for field in API_TOKEN_FIELDS:
+            self.data[field] = data.get(field)
 
-    def _get_aes_key(self):
-        email_beginning = self.config_data.username[:2]
-
-        password = f"{email_beginning}ha".lower()
-
-        password_bytes = password.encode()
-
-        encryption_hash = hashlib.md5(password_bytes)
-        encryption_key = encryption_hash.digest()
-
-        return encryption_key
+        self._set_status(ConnectivityStatus.CONNECTED)
 
     def _set_status(self, status: ConnectivityStatus, message: str | None = None):
         log_level = ConnectivityStatus.get_log_level(status)
 
         if status != self._status:
             log_message = f"Status update {self._status} --> {status}"
-
             if message is not None:
                 log_message = f"{log_message}, {message}"
-
             _LOGGER.log(log_level, log_message)
-
             self._status = status
-
             self._async_dispatcher_send(
                 SIGNAL_API_STATUS, self._config_manager.entry_id, status
             )
-
         else:
             log_message = f"Status is {status}"
-
-            if message is None:
+            if message is not None:
                 log_message = f"{log_message}, {message}"
-
             _LOGGER.log(log_level, log_message)
-
-    async def _handle_client_error(
-        self, endpoint: str, method: str, crex: ClientResponseError
-    ):
-        message = (
-            "Failed to send HTTP request, "
-            f"Endpoint: {endpoint}, "
-            f"Method: {method}, "
-            f"HTTP Status: {crex.message} ({crex.status})"
-        )
-
-        if crex.status in [401]:
-            await self._clean_login_details()
-
-            self._set_status(ConnectivityStatus.EXPIRED_TOKEN, message)
-
-        if crex.status in [404, 405]:
-            self._set_status(ConnectivityStatus.API_NOT_FOUND, message)
-
-        else:
-            self._set_status(ConnectivityStatus.FAILED, message)
-
-    def _handle_server_timeout(self, endpoint: str, method: str):
-        message = (
-            "Failed to send HTTP request due to timeout, "
-            f"Endpoint: {endpoint}, "
-            f"Method: {method}"
-        )
-
-        self._set_status(ConnectivityStatus.FAILED, message)
-
-    def _handle_general_request_failure(
-        self, endpoint: str, method: str, ex: Exception
-    ):
-        exc_type, exc_obj, tb = sys.exc_info()
-        line_number = tb.tb_lineno
-
-        message = (
-            "Failed to send HTTP request, "
-            f"Endpoint: {endpoint}, "
-            f"Method: {method}, "
-            f"Error: {ex}, "
-            f"Line: {line_number}"
-        )
-
-        self._set_status(ConnectivityStatus.FAILED, message)
 
     def set_local_async_dispatcher_send(self, callback):
         self._local_async_dispatcher_send = callback
@@ -613,6 +379,5 @@ class RestAPI:
     def _async_dispatcher_send(self, signal: str, *args: Any) -> None:
         if self._hass is None:
             self._local_async_dispatcher_send(signal, *args)
-
         else:
             dispatcher_send(self._hass, signal, *args)

--- a/custom_components/mydolphin_plus/manifest.json
+++ b/custom_components/mydolphin_plus/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/sh00t2kill/dolphin-robot/issues",
   "requirements": ["awsiotsdk"],
-  "version": "1.0.23"
+  "version": "1.0.24"
 }

--- a/custom_components/mydolphin_plus/models/config_data.py
+++ b/custom_components/mydolphin_plus/models/config_data.py
@@ -1,62 +1,48 @@
 import voluptuous as vol
 from voluptuous import Schema
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_USERNAME
 
-from ..common.consts import CONF_TITLE, DEFAULT_NAME
+from ..common.consts import CONF_OTP, CONF_TITLE, DEFAULT_NAME
 
-DATA_KEYS = [CONF_USERNAME, CONF_PASSWORD]
+DATA_KEYS = [CONF_USERNAME]
 
 
 class ConfigData:
     _username: str | None
-    _password: str | None
 
     def __init__(self):
         self._username = None
-        self._password = None
 
     @property
     def username(self) -> str:
-        username = self._username
-
-        return username
-
-    @property
-    def password(self) -> str:
-        password = self._password
-
-        return password
+        return self._username
 
     def update(self, data: dict):
-        self._password = data.get(CONF_PASSWORD)
         self._username = data.get(CONF_USERNAME)
 
     def to_dict(self):
-        obj = {
-            CONF_USERNAME: self.username,
-        }
-
-        return obj
+        return {CONF_USERNAME: self.username}
 
     def __repr__(self):
-        to_string = f"{self.to_dict()}"
-
-        return to_string
+        return f"{self.to_dict()}"
 
     @staticmethod
     def default_schema(user_input: dict | None) -> Schema:
         if user_input is None:
             user_input = {}
 
-        new_user_input = {
-            vol.Required(
-                CONF_TITLE, default=user_input.get(CONF_TITLE, DEFAULT_NAME)
-            ): str,
-            vol.Required(CONF_USERNAME, default=user_input.get(CONF_USERNAME)): str,
-            vol.Required(CONF_PASSWORD, default=user_input.get(CONF_PASSWORD)): str,
-        }
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_TITLE, default=user_input.get(CONF_TITLE, DEFAULT_NAME)
+                ): str,
+                vol.Required(
+                    CONF_USERNAME, default=user_input.get(CONF_USERNAME)
+                ): str,
+            }
+        )
 
-        schema = vol.Schema(new_user_input)
-
-        return schema
+    @staticmethod
+    def otp_schema() -> Schema:
+        return vol.Schema({vol.Required(CONF_OTP): str})

--- a/custom_components/mydolphin_plus/models/exceptions.py
+++ b/custom_components/mydolphin_plus/models/exceptions.py
@@ -1,3 +1,4 @@
 class LoginError(Exception):
-    def __init__(self):
-        self.error = "Failed to login"
+    def __init__(self, message: str = "Failed to login"):
+        super().__init__(message)
+        self.error = message

--- a/custom_components/mydolphin_plus/strings.json
+++ b/custom_components/mydolphin_plus/strings.json
@@ -3,42 +3,52 @@
     "step": {
       "user": {
         "title": "Set up MyDolphin Plus",
-        "description": "Set up your MyDolphin Plus details",
+        "description": "Enter your MyDolphin Plus account email. A login code will be sent to your inbox.",
         "data": {
-          "username": "Username",
-          "password": "Password",
-          "reset_password": "Reset account password (Workaround for OTP)"
+          "title": "Title",
+          "username": "Email"
+        }
+      },
+      "otp": {
+        "title": "Confirm OTP",
+        "description": "Enter the login code sent to your email.",
+        "data": {
+          "otp": "Login code"
         }
       }
     },
     "error": {
-      "invalid_credentials": "Invalid credentials",
       "invalid_account": "Invalid account",
+      "invalid_otp": "Invalid or expired login code",
+      "otp_send_failed": "Failed to send login code, check the email and try again",
       "invalid_server_details": "Invalid server details",
-      "already_configured": "Integration already configured with the name",
-      "missing_permanent_api_key": "Missing permanent API key",
-      "corrupted_encryption_key": "Encryption key got corrupted, please remove the integration and re-add it"
+      "already_configured": "Integration already configured with the name"
     }
   },
   "options": {
     "step": {
-      "mydolphin_plus_additional_settings": {
-        "title": "Options for MyDolphin Plus.",
-        "description": "Set up username and password.",
+      "init": {
+        "title": "Re-authenticate MyDolphin Plus",
+        "description": "Enter your MyDolphin Plus email to receive a fresh login code.",
         "data": {
-          "username": "Username",
-          "password": "Password",
-          "reset_password": "Reset account password (Workaround for OTP)"
+          "title": "Title",
+          "username": "Email"
+        }
+      },
+      "otp": {
+        "title": "Confirm OTP",
+        "description": "Enter the login code sent to your email.",
+        "data": {
+          "otp": "Login code"
         }
       }
     },
     "error": {
-      "invalid_credentials": "Invalid credentials",
       "invalid_account": "Invalid account",
+      "invalid_otp": "Invalid or expired login code",
+      "otp_send_failed": "Failed to send login code, check the email and try again",
       "invalid_server_details": "Invalid server details",
-      "already_configured": "Integration already configured with the name",
-      "missing_permanent_api_key": "Missing permanent API key",
-      "corrupted_encryption_key": "Encryption key got corrupted, please remove the integration and re-add it"
+      "already_configured": "Integration already configured with the name"
     }
   },
   "entity": {

--- a/custom_components/mydolphin_plus/translations/en.json
+++ b/custom_components/mydolphin_plus/translations/en.json
@@ -2,21 +2,26 @@
   "config": {
     "error": {
       "already_configured": "Integration already configured with the name",
-      "corrupted_encryption_key": "Encryption key got corrupted, please remove the integration and re-add it",
       "invalid_account": "Invalid account",
-      "invalid_credentials": "Invalid credentials",
+      "invalid_otp": "Invalid or expired login code",
       "invalid_server_details": "Invalid server details",
-      "missing_permanent_api_key": "Missing permanent API key"
+      "otp_send_failed": "Failed to send login code, check the email and try again"
     },
     "step": {
       "user": {
         "data": {
-          "password": "Password",
-          "reset_password": "Reset account password (Workaround for OTP)",
-          "username": "Username"
+          "title": "Title",
+          "username": "Email"
         },
-        "description": "Set up your MyDolphin Plus details",
+        "description": "Enter your MyDolphin Plus account email. A login code will be sent to your inbox.",
         "title": "Set up MyDolphin Plus"
+      },
+      "otp": {
+        "data": {
+          "otp": "Login code"
+        },
+        "description": "Enter the login code sent to your email.",
+        "title": "Confirm OTP"
       }
     }
   },
@@ -247,21 +252,26 @@
   "options": {
     "error": {
       "already_configured": "Integration already configured with the name",
-      "corrupted_encryption_key": "Encryption key got corrupted, please remove the integration and re-add it",
       "invalid_account": "Invalid account",
-      "invalid_credentials": "Invalid credentials",
+      "invalid_otp": "Invalid or expired login code",
       "invalid_server_details": "Invalid server details",
-      "missing_permanent_api_key": "Missing permanent API key"
+      "otp_send_failed": "Failed to send login code, check the email and try again"
     },
     "step": {
-      "mydolphin_plus_additional_settings": {
+      "init": {
         "data": {
-          "password": "Password",
-          "reset_password": "Reset account password (Workaround for OTP)",
-          "username": "Username"
+          "title": "Title",
+          "username": "Email"
         },
-        "description": "Set up username and password.",
-        "title": "Options for MyDolphin Plus."
+        "description": "Enter your MyDolphin Plus email to receive a fresh login code.",
+        "title": "Re-authenticate MyDolphin Plus"
+      },
+      "otp": {
+        "data": {
+          "otp": "Login code"
+        },
+        "description": "Enter the login code sent to your email.",
+        "title": "Confirm OTP"
       }
     }
   }

--- a/custom_components/mydolphin_plus/translations/it.json
+++ b/custom_components/mydolphin_plus/translations/it.json
@@ -2,21 +2,26 @@
   "config": {
     "error": {
       "already_configured": "Integrazione gi\u00e0 configurata con il nome",
-      "corrupted_encryption_key": "La chiave di crittografia \u00e8 stata danneggiata, rimuovi l'integrazione e lo aggiunge",
       "invalid_account": "Account non valido",
-      "invalid_credentials": "Credenziali non valide",
+      "invalid_otp": "Codice di accesso non valido o scaduto",
       "invalid_server_details": "Dettagli del server non validi",
-      "missing_permanent_api_key": "Chiave API permanente mancante"
+      "otp_send_failed": "Invio del codice di accesso non riuscito, verifica l'e-mail e riprova"
     },
     "step": {
       "user": {
         "data": {
-          "password": "Parola d'ordine",
-          "reset_password": "Reimpostare la password dell'account (soluzione alternativa per OTP)",
-          "username": "Nome utente"
+          "title": "Titolo",
+          "username": "Email"
         },
-        "description": "Imposta i tuoi dettagli MyDolphin Plus",
-        "title": "Imposta mydolphin plus"
+        "description": "Inserisci l'email del tuo account MyDolphin Plus. Riceverai un codice di accesso via email.",
+        "title": "Imposta MyDolphin Plus"
+      },
+      "otp": {
+        "data": {
+          "otp": "Codice di accesso"
+        },
+        "description": "Inserisci il codice di accesso ricevuto via email.",
+        "title": "Conferma OTP"
       }
     }
   },
@@ -247,21 +252,26 @@
   "options": {
     "error": {
       "already_configured": "Integrazione gi\u00e0 configurata con il nome",
-      "corrupted_encryption_key": "La chiave di crittografia \u00e8 stata danneggiata, rimuovi l'integrazione e lo aggiunge",
       "invalid_account": "Account non valido",
-      "invalid_credentials": "Credenziali non valide",
+      "invalid_otp": "Codice di accesso non valido o scaduto",
       "invalid_server_details": "Dettagli del server non validi",
-      "missing_permanent_api_key": "Chiave API permanente mancante"
+      "otp_send_failed": "Invio del codice di accesso non riuscito, verifica l'e-mail e riprova"
     },
     "step": {
-      "mydolphin_plus_additional_settings": {
+      "init": {
         "data": {
-          "password": "Parola d'ordine",
-          "reset_password": "Reimpostare la password dell'account (soluzione alternativa per OTP)",
-          "username": "Nome utente"
+          "title": "Titolo",
+          "username": "Email"
         },
-        "description": "Imposta nome utente e password.",
-        "title": "Opzioni per MyDolphin Plus."
+        "description": "Inserisci l'email del tuo account MyDolphin Plus per ricevere un nuovo codice di accesso.",
+        "title": "Riautentica MyDolphin Plus"
+      },
+      "otp": {
+        "data": {
+          "otp": "Codice di accesso"
+        },
+        "description": "Inserisci il codice di accesso ricevuto via email.",
+        "title": "Conferma OTP"
       }
     }
   }


### PR DESCRIPTION
Maytronics retired the legacy mbapp18.maytronics.com email/password login. Switch to the working scheme: Cognito CUSTOM_AUTH email OTP + bearer-token calls against apps.maytronics.com.

- Two-step config flow: collect email -> trigger Cognito InitiateAuth ->
  collect OTP -> RespondToAuthChallenge -> fetch profile + AWS STS creds
- Persist id-token, refresh-token, id-token-expires-at; refresh via REFRESH_TOKEN_AUTH when within 5 min of expiry
- Swap periodic robot details refresh to apps.maytronics.com/mobapi/ user/authenticate-user/ and AWS creds to /mt-sso/aws/getToken/
- Drop password field, AES helpers, email-validation, reset-password
- Existing users: remove and re-add the integration after upgrading
- Bump version to 1.0.24