### PR TITLE
Post otp merge fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 26.3.1
     hooks:
       - id: black
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.26b1
+
+- Merge pull request [#270](https://github.com/sh00t2kill/dolphin-robot/pull/270) from `yumlevi/cognito-otp-login`
+- Replace login flow with Cognito OTP login flow
+
 ## v1.0.25
 
 - Fix AWS token generation errors for users upgrading from older versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Merge pull request [#270](https://github.com/sh00t2kill/dolphin-robot/pull/270) from `yumlevi/cognito-otp-login`
 - Replace login flow with Cognito OTP login flow
+- Add Home Assistant native reauthentication flow for expired or invalid credentials
+- Trigger linked reauth prompt when refresh token is missing/expired, including for users upgrading from versions earlier than OTP support
 
 ## v1.0.25
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Authentication uses the same email-OTP flow as the official MyDolphin Plus mobil
 
 The refresh token is reused on every Home Assistant restart and silently renewed (~hourly), so you should only need to re-enter an OTP if the refresh token expires (Cognito default ~30 days) or you remove and re-add the integration.
 
-> **Upgrading from a pre-OTP version (≤ 1.0.25b5):** the legacy email/password login endpoint has been retired by Maytronics. After updating, **remove the integration and re-add it** to go through the OTP flow.
+> **Upgrading from a pre-OTP version (≤ 1.0.25b5):** the legacy email/password login endpoint has been retired by Maytronics. After updating, Home Assistant should prompt you to **Reconfigure / Reauthenticate** the existing entry so you can complete OTP login without reinstalling.
 
 ## How to
 
@@ -219,7 +219,9 @@ Please attach also diagnostic details of the integration, available in:
 
 ### Refresh token expired
 
-If the integration logs `EXPIRED_TOKEN` and stops loading, the stored Cognito `RefreshToken` is no longer valid (it has expired or been invalidated server-side). Remove and re-add the integration to go through the OTP flow again.
+If the integration logs `EXPIRED_TOKEN` and stops loading, the stored Cognito `RefreshToken` is no longer valid (it has expired or been invalidated server-side). Home Assistant should raise a reauthentication prompt for the existing entry so you can complete the OTP flow again.
+
+If reauthentication does not appear or cannot be completed, remove and re-add the integration as a fallback.
 
 The token state lives in `.storage/mydolphin_plus.config.json`, keyed by the entry id:
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The refresh token is reused on every Home Assistant restart and silently renewed
 
 ###### Basic configuration (Configuration -> Integrations -> Add MyDolphin Plus)
 
-| Field      | Type    | Required | Description                                                                                |
-| ---------- | ------- | -------- | ------------------------------------------------------------------------------------------ |
-| Title      | Textbox | yes      | Display name for the integration entry                                                     |
-| Email      | Textbox | yes      | Email of your MyDolphin Plus account — Maytronics emails a login code to this address      |
-| Login code | Textbox | yes      | The one-time code from the email, entered on the second step of the config flow            |
+| Field      | Type    | Required | Description                                                                           |
+| ---------- | ------- | -------- | ------------------------------------------------------------------------------------- |
+| Title      | Textbox | yes      | Display name for the integration entry                                                |
+| Email      | Textbox | yes      | Email of your MyDolphin Plus account — Maytronics emails a login code to this address |
+| Login code | Textbox | yes      | The one-time code from the email, entered on the second step of the config flow       |
 
 ###### Configuration validations
 

--- a/custom_components/mydolphin_plus/__init__.py
+++ b/custom_components/mydolphin_plus/__init__.py
@@ -3,11 +3,12 @@ This component provides support for MyDolphin Plus.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mydolphin_plus/
 """
+
 import logging
 import sys
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_START, CONF_USERNAME
+from homeassistant.const import CONF_USERNAME, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant
 
 from .common.consts import (

--- a/custom_components/mydolphin_plus/common/consts.py
+++ b/custom_components/mydolphin_plus/common/consts.py
@@ -143,6 +143,7 @@ AWS_CREDENTIALS_EXPIRY = "aws_credentials_expiry"
 # Rate limiting for token fetches
 MIN_TOKEN_FETCH_INTERVAL = timedelta(minutes=5)  # Minimum time between token API calls
 STORAGE_DATA_LAST_TOKEN_FETCH = "last-token-fetch"
+STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH = "last-aws-credentials-fetch"
 
 WS_LAST_UPDATE = "last-update"
 
@@ -334,6 +335,7 @@ TOKEN_PARAMS = [
     STORAGE_DATA_ID_TOKEN,
     STORAGE_DATA_REFRESH_TOKEN,
     STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
+    STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH,
     STORAGE_DATA_SERIAL_NUMBER,
     STORAGE_DATA_MOTOR_UNIT_SERIAL,
     STORAGE_DATA_LAST_TOKEN_FETCH,

--- a/custom_components/mydolphin_plus/common/integration_info.py
+++ b/custom_components/mydolphin_plus/common/integration_info.py
@@ -1,4 +1,5 @@
 """Integration information handler."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/mydolphin_plus/config_flow.py
+++ b/custom_components/mydolphin_plus/config_flow.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
+from typing import Any
+
+import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.core import callback
 
 from .common.consts import DOMAIN
@@ -37,8 +41,33 @@ class DomainFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_otp(self, user_input=None):
         """Handle the OTP confirmation step."""
-        flow_manager = IntegrationFlowManager(self.hass, self)
+        flow_manager = IntegrationFlowManager(
+            self.hass,
+            self,
+            source=self.source,
+        )
         return await flow_manager.async_step_otp(user_input)
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]):
+        """Start reauthentication flow linked to current config entry."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Confirm reauthentication and continue with OTP login flow."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=vol.Schema({}),
+            )
+
+        entry = self._get_reauth_entry()
+        flow_manager = IntegrationFlowManager(
+            self.hass,
+            self,
+            entry=entry,
+            source=SOURCE_REAUTH,
+        )
+        return await flow_manager.async_step_user(None)
 
 
 class DomainOptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/mydolphin_plus/config_flow.py
+++ b/custom_components/mydolphin_plus/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow to configure."""
+
 from __future__ import annotations
 
 import logging
@@ -52,13 +53,9 @@ class DomainOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         """Manage the domain options (re-trigger OTP login)."""
-        flow_manager = IntegrationFlowManager(
-            self.hass, self, self._config_entry
-        )
+        flow_manager = IntegrationFlowManager(self.hass, self, self._config_entry)
         return await flow_manager.async_step_user(user_input)
 
     async def async_step_otp(self, user_input=None):
-        flow_manager = IntegrationFlowManager(
-            self.hass, self, self._config_entry
-        )
+        flow_manager = IntegrationFlowManager(self.hass, self, self._config_entry)
         return await flow_manager.async_step_otp(user_input)

--- a/custom_components/mydolphin_plus/diagnostics.py
+++ b/custom_components/mydolphin_plus/diagnostics.py
@@ -1,4 +1,5 @@
 """Diagnostics support for MyDolphin."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/mydolphin_plus/managers/config_manager.py
+++ b/custom_components/mydolphin_plus/managers/config_manager.py
@@ -28,6 +28,7 @@ from ..common.consts import (
     RECONNECT_BACKOFF_MAX,
     STORAGE_DATA_ID_TOKEN,
     STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
+    STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH,
     STORAGE_DATA_LAST_TOKEN_FETCH,
     STORAGE_DATA_LOCATING,
     STORAGE_DATA_MOTOR_UNIT_SERIAL,
@@ -132,6 +133,11 @@ class ConfigManager:
     @property
     def last_token_fetch(self) -> float:
         timestamp = self._data.get(STORAGE_DATA_LAST_TOKEN_FETCH, 0) or 0
+        return timestamp
+
+    @property
+    def last_aws_credentials_fetch(self) -> float:
+        timestamp = self._data.get(STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH, 0) or 0
         return timestamp
 
     @property
@@ -257,7 +263,7 @@ class ConfigManager:
 
     async def _validate_cached_credentials(self):
         """Check if cached credentials are too old and clear them if needed."""
-        last_fetch = self._data.get(STORAGE_DATA_LAST_TOKEN_FETCH, 0) or 0
+        last_fetch = self._data.get(STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH, 0) or 0
 
         if last_fetch == 0:
             return  # No cached credentials to validate
@@ -317,6 +323,11 @@ class ConfigManager:
             self._data[STORAGE_DATA_LAST_TOKEN_FETCH] = timestamp
             await self._save()
 
+    async def update_last_aws_credentials_fetch(self, timestamp: float):
+        if timestamp is not None:
+            self._data[STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH] = timestamp
+            await self._save()
+
     async def update_aws_credentials_expiry(self, expiry: float):
         if expiry is not None:
             self._data[AWS_CREDENTIALS_EXPIRY] = expiry
@@ -365,6 +376,7 @@ class ConfigManager:
         data = {
             STORAGE_DATA_LOCATING: False,
             STORAGE_DATA_LAST_TOKEN_FETCH: 0,
+            STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH: 0,
             AWS_CREDENTIALS_EXPIRY: 0,
         }
 

--- a/custom_components/mydolphin_plus/managers/coordinator.py
+++ b/custom_components/mydolphin_plus/managers/coordinator.py
@@ -150,6 +150,7 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
         self._last_update_api = 0
         self._last_update_ws = 0
         self._reconnection_attempts = 0
+        self._reauth_in_progress = False
 
         # MQTT debouncing
         self._mqtt_debouncer = Debouncer(
@@ -276,6 +277,7 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
 
         if status == ConnectivityStatus.CONNECTED:
             self._reconnection_attempts = 0  # Reset backoff counter on success
+            self._reauth_in_progress = False
 
             await self._api.update()
 
@@ -288,7 +290,24 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
             ConnectivityStatus.INVALID_CREDENTIALS,
             ConnectivityStatus.EXPIRED_TOKEN,
         ]:
+            if status == ConnectivityStatus.EXPIRED_TOKEN:
+                await self._start_reauth_if_needed()
             await self._handle_connection_failure()
+
+    async def _start_reauth_if_needed(self):
+        if self._reauth_in_progress:
+            return
+
+        entry = self.config_manager.entry
+        if entry is None:
+            return
+
+        try:
+            await entry.async_start_reauth(self.hass)
+            self._reauth_in_progress = True
+            _LOGGER.warning("Started Home Assistant reauthentication flow")
+        except Exception as ex:
+            _LOGGER.error(f"Failed to start Home Assistant reauthentication flow: {ex}")
 
     async def _on_aws_client_status_changed(
         self, entry_id: str, status: ConnectivityStatus

--- a/custom_components/mydolphin_plus/managers/flow_manager.py
+++ b/custom_components/mydolphin_plus/managers/flow_manager.py
@@ -1,4 +1,5 @@
 """Config flow to configure."""
+
 from __future__ import annotations
 
 import logging
@@ -23,11 +24,7 @@ from ..common.consts import (
 )
 from ..models.config_data import ConfigData
 from ..models.exceptions import LoginError
-from .rest_api import (
-    cognito_initiate_auth,
-    cognito_respond_otp,
-    fetch_user_profile,
-)
+from .rest_api import cognito_initiate_auth, cognito_respond_otp, fetch_user_profile
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,9 +77,7 @@ class IntegrationFlowManager:
             init = await cognito_initiate_auth(session, email)
         except LoginError as ex:
             _LOGGER.warning(f"Cognito InitiateAuth failed: {ex}")
-            return self._show_user_form(
-                user_input, errors={"base": "otp_send_failed"}
-            )
+            return self._show_user_form(user_input, errors={"base": "otp_send_failed"})
 
         setattr(
             self._flow_handler,

--- a/custom_components/mydolphin_plus/managers/flow_manager.py
+++ b/custom_components/mydolphin_plus/managers/flow_manager.py
@@ -22,6 +22,7 @@ from ..common.consts import (
     STORAGE_DATA_REFRESH_TOKEN,
     STORAGE_DATA_SERIAL_NUMBER,
 )
+from ..common.integration_info import IntegrationInfo
 from ..models.config_data import ConfigData
 from ..models.exceptions import LoginError
 from .rest_api import cognito_initiate_auth, cognito_respond_otp, fetch_user_profile
@@ -37,6 +38,7 @@ class IntegrationFlowManager:
 
     _flow_handler: FlowHandler
     _flow_id: str
+    _integration_info: IntegrationInfo
 
     def __init__(
         self,
@@ -48,6 +50,7 @@ class IntegrationFlowManager:
         self._flow_handler = flow_handler
         self._entry = entry
         self._flow_id = "user" if entry is None else "init"
+        self._integration_info = IntegrationInfo()
 
     async def async_step(self, user_input: dict | None = None):
         return await self.async_step_user(user_input)
@@ -73,8 +76,13 @@ class IntegrationFlowManager:
             return self._show_user_form(user_input, errors={"base": "invalid_account"})
 
         session = async_get_clientsession(self._hass)
+        await self._integration_info.initialize(self._hass)
         try:
-            init = await cognito_initiate_auth(session, email)
+            init = await cognito_initiate_auth(
+                session,
+                email,
+                integration_info=self._integration_info,
+            )
         except LoginError as ex:
             _LOGGER.warning(f"Cognito InitiateAuth failed: {ex}")
             return self._show_user_form(user_input, errors={"base": "otp_send_failed"})
@@ -104,11 +112,20 @@ class IntegrationFlowManager:
             return self._show_otp_form(errors={"base": "invalid_otp"})
 
         session = async_get_clientsession(self._hass)
+        await self._integration_info.initialize(self._hass)
         try:
             auth = await cognito_respond_otp(
-                session, state["email"], state["cognito_session"], code
+                session,
+                state["email"],
+                state["cognito_session"],
+                code,
+                integration_info=self._integration_info,
             )
-            profile = await fetch_user_profile(session, auth["IdToken"])
+            profile = await fetch_user_profile(
+                session,
+                auth["IdToken"],
+                integration_info=self._integration_info,
+            )
         except LoginError as ex:
             _LOGGER.warning(f"OTP exchange failed: {ex}")
             return self._show_otp_form(errors={"base": "invalid_otp"})

--- a/custom_components/mydolphin_plus/managers/flow_manager.py
+++ b/custom_components/mydolphin_plus/managers/flow_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowHandler
@@ -45,11 +45,16 @@ class IntegrationFlowManager:
         hass: HomeAssistant,
         flow_handler: FlowHandler,
         entry: ConfigEntry | None = None,
+        source: str | None = None,
     ):
         self._hass = hass
         self._flow_handler = flow_handler
         self._entry = entry
-        self._flow_id = "user" if entry is None else "init"
+        self._source = (
+            source if source is not None else getattr(flow_handler, "source", None)
+        )
+        self._is_reauth = self._source == SOURCE_REAUTH
+        self._flow_id = "user" if entry is None or self._is_reauth else "init"
         self._integration_info = IntegrationInfo()
 
     async def async_step(self, user_input: dict | None = None):
@@ -143,6 +148,15 @@ class IntegrationFlowManager:
             delattr(self._flow_handler, _FLOW_STATE_ATTR)
         except AttributeError:
             pass
+
+        if self._is_reauth:
+            return self._flow_handler.async_update_reload_and_abort(
+                self._flow_handler._get_reauth_entry(),
+                data_updates={
+                    CONF_USERNAME: state["email"],
+                    INITIAL_TOKENS_KEY: initial_tokens,
+                },
+            )
 
         if self._entry is not None:
             self._hass.config_entries.async_update_entry(

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -267,9 +267,7 @@ class RestAPI:
 
         self._device_loaded = True
 
-        self._async_dispatcher_send(
-            SIGNAL_DEVICE_NEW, self._config_manager.entry_id
-        )
+        self._async_dispatcher_send(SIGNAL_DEVICE_NEW, self._config_manager.entry_id)
 
         _LOGGER.debug(f"API Data updated: {self.data}")
 
@@ -385,7 +383,8 @@ class RestAPI:
         if not data:
             alert = payload.get(API_RESPONSE_ALERT)
             self._set_status(
-                ConnectivityStatus.FAILED, f"authenticate-user empty data, Alert: {alert}"
+                ConnectivityStatus.FAILED,
+                f"authenticate-user empty data, Alert: {alert}",
             )
             return False
 

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -47,21 +47,37 @@ from .config_manager import ConfigManager
 _LOGGER = logging.getLogger(__name__)
 
 
-def _bearer_headers(id_token: str, extra: dict | None = None) -> dict:
-    headers = {
-        "Authorization": f"Bearer {id_token}",
-        **BEARER_HEADERS_BASE,
-    }
+def _build_headers(
+    base: dict | None = None,
+    id_token: str | None = None,
+    extra: dict | None = None,
+    integration_info: IntegrationInfo | None = None,
+) -> dict:
+    headers = {}
+    if base:
+        headers.update(base)
+    if id_token:
+        headers["Authorization"] = f"Bearer {id_token}"
     if extra:
         headers.update(extra)
+    if integration_info is not None:
+        integration_info.set_user_agent(headers)
     return headers
 
 
-async def _cognito_call(session: ClientSession, target: str, body: dict) -> dict:
-    headers = {
-        "Content-Type": COGNITO_CONTENT_TYPE,
-        COGNITO_HEADER_TARGET: f"{COGNITO_TARGET_PREFIX}{target}",
-    }
+async def _cognito_call(
+    session: ClientSession,
+    target: str,
+    body: dict,
+    integration_info: IntegrationInfo | None = None,
+) -> dict:
+    headers = _build_headers(
+        base={
+            "Content-Type": COGNITO_CONTENT_TYPE,
+            COGNITO_HEADER_TARGET: f"{COGNITO_TARGET_PREFIX}{target}",
+        },
+        integration_info=integration_info,
+    )
     try:
         async with session.post(
             COGNITO_ENDPOINT, headers=headers, data=json.dumps(body)
@@ -80,7 +96,11 @@ async def _cognito_call(session: ClientSession, target: str, body: dict) -> dict
         raise LoginError(f"Cognito {target} request failed: {ex}") from ex
 
 
-async def cognito_initiate_auth(session: ClientSession, email: str) -> dict:
+async def cognito_initiate_auth(
+    session: ClientSession,
+    email: str,
+    integration_info: IntegrationInfo | None = None,
+) -> dict:
     response = await _cognito_call(
         session,
         "InitiateAuth",
@@ -90,6 +110,7 @@ async def cognito_initiate_auth(session: ClientSession, email: str) -> dict:
             "AuthParameters": {"USERNAME": email},
             "ClientMetadata": {},
         },
+        integration_info=integration_info,
     )
     if response.get("ChallengeName") != COGNITO_CHALLENGE_NAME:
         raise LoginError(
@@ -99,7 +120,11 @@ async def cognito_initiate_auth(session: ClientSession, email: str) -> dict:
 
 
 async def cognito_respond_otp(
-    session: ClientSession, email: str, cognito_session: str, code: str
+    session: ClientSession,
+    email: str,
+    cognito_session: str,
+    code: str,
+    integration_info: IntegrationInfo | None = None,
 ) -> dict:
     response = await _cognito_call(
         session,
@@ -111,6 +136,7 @@ async def cognito_respond_otp(
             "ChallengeResponses": {"USERNAME": email, "ANSWER": code},
             "ClientMetadata": {},
         },
+        integration_info=integration_info,
     )
     auth = response.get("AuthenticationResult")
     if not auth or "IdToken" not in auth:
@@ -118,7 +144,11 @@ async def cognito_respond_otp(
     return auth
 
 
-async def cognito_refresh(session: ClientSession, refresh_token: str) -> dict:
+async def cognito_refresh(
+    session: ClientSession,
+    refresh_token: str,
+    integration_info: IntegrationInfo | None = None,
+) -> dict:
     response = await _cognito_call(
         session,
         "InitiateAuth",
@@ -128,6 +158,7 @@ async def cognito_refresh(session: ClientSession, refresh_token: str) -> dict:
             "AuthParameters": {"REFRESH_TOKEN": refresh_token},
             "ClientMetadata": {},
         },
+        integration_info=integration_info,
     )
     auth = response.get("AuthenticationResult")
     if not auth or "IdToken" not in auth:
@@ -135,10 +166,16 @@ async def cognito_refresh(session: ClientSession, refresh_token: str) -> dict:
     return auth
 
 
-async def fetch_user_profile(session: ClientSession, id_token: str) -> dict:
-    headers = _bearer_headers(
-        id_token,
-        {"Content-Type": "application/x-www-form-urlencoded"},
+async def fetch_user_profile(
+    session: ClientSession,
+    id_token: str,
+    integration_info: IntegrationInfo | None = None,
+) -> dict:
+    headers = _build_headers(
+        base=BEARER_HEADERS_BASE,
+        id_token=id_token,
+        extra={"Content-Type": "application/x-www-form-urlencoded"},
+        integration_info=integration_info,
     )
     try:
         async with session.post(
@@ -159,8 +196,16 @@ async def fetch_user_profile(session: ClientSession, id_token: str) -> dict:
     return data
 
 
-async def fetch_aws_credentials(session: ClientSession, id_token: str) -> dict:
-    headers = _bearer_headers(id_token)
+async def fetch_aws_credentials(
+    session: ClientSession,
+    id_token: str,
+    integration_info: IntegrationInfo | None = None,
+) -> dict:
+    headers = _build_headers(
+        base=BEARER_HEADERS_BASE,
+        id_token=id_token,
+        integration_info=integration_info,
+    )
     try:
         async with session.get(AWS_STS_TOKEN_URL, headers=headers) as response:
             response.raise_for_status()
@@ -309,7 +354,11 @@ class RestAPI:
             return False
 
         try:
-            auth = await cognito_refresh(self._session, refresh_token)
+            auth = await cognito_refresh(
+                self._session,
+                refresh_token,
+                integration_info=self._integration_info,
+            )
         except LoginError as ex:
             await self._config_manager.reset_login_details()
             self._set_status(
@@ -330,16 +379,20 @@ class RestAPI:
     async def _bearer_post(
         self, url: str, body: str | dict | None = None
     ) -> dict | None:
-        headers = _bearer_headers(
-            self._config_manager.id_token,
-            {"Content-Type": "application/x-www-form-urlencoded"},
+        headers = _build_headers(
+            base=BEARER_HEADERS_BASE,
+            id_token=self._config_manager.id_token,
+            extra={"Content-Type": "application/x-www-form-urlencoded"},
+            integration_info=self._integration_info,
         )
-        self._integration_info.set_user_agent(headers)
         return await self._async_send(METH_POST, url, headers, data=body or "")
 
     async def _bearer_get(self, url: str) -> dict | None:
-        headers = _bearer_headers(self._config_manager.id_token)
-        self._integration_info.set_user_agent(headers)
+        headers = _build_headers(
+            base=BEARER_HEADERS_BASE,
+            id_token=self._config_manager.id_token,
+            integration_info=self._integration_info,
+        )
         return await self._async_send(METH_GET, url, headers)
 
     async def _async_send(
@@ -415,7 +468,7 @@ class RestAPI:
 
         # Rate limit fresh fetches; fall back to (potentially stale) cache when limited
         now = datetime.now().timestamp()
-        last_fetch = self._config_manager.last_token_fetch
+        last_fetch = self._config_manager.last_aws_credentials_fetch
         time_since_last = now - last_fetch
 
         if (
@@ -428,10 +481,17 @@ class RestAPI:
                 f"Need to wait {wait_time:.0f}s more."
             )
             if self._has_cached_credentials():
+                if await self._are_cached_credentials_valid():
+                    _LOGGER.info("Using cached AWS IoT credentials due to rate limit")
+                    self._set_status(ConnectivityStatus.CONNECTED)
+                    return
                 _LOGGER.info(
-                    "Using potentially expired cached credentials due to rate limit"
+                    "Cached AWS credentials are expired and refresh is rate limited"
                 )
-                self._set_status(ConnectivityStatus.CONNECTED)
+                self._set_status(
+                    ConnectivityStatus.FAILED,
+                    "AWS credentials expired and refresh is rate-limited",
+                )
                 return
             _LOGGER.warning(
                 "No cached credentials available, attempting fetch despite rate limit"
@@ -441,7 +501,9 @@ class RestAPI:
 
         try:
             data = await fetch_aws_credentials(
-                self._session, self._config_manager.id_token
+                self._session,
+                self._config_manager.id_token,
+                integration_info=self._integration_info,
             )
         except LoginError as ex:
             self._set_status(ConnectivityStatus.FAILED, f"getToken: {ex}")
@@ -452,7 +514,7 @@ class RestAPI:
 
         now = datetime.now().timestamp()
         expiry = now + AWS_CREDENTIALS_TTL.total_seconds()
-        await self._config_manager.update_last_token_fetch(now)
+        await self._config_manager.update_last_aws_credentials_fetch(now)
         await self._config_manager.update_aws_credentials_expiry(expiry)
 
         _LOGGER.info(

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -320,7 +320,7 @@ class RestAPI:
         if self._config_manager.refresh_token is None:
             self._set_status(
                 ConnectivityStatus.EXPIRED_TOKEN,
-                "no refresh token stored — remove and re-add the integration",
+                "no refresh token stored — reauthentication required",
             )
             return
 
@@ -349,7 +349,7 @@ class RestAPI:
         if not refresh_token:
             self._set_status(
                 ConnectivityStatus.EXPIRED_TOKEN,
-                "no refresh token available — remove and re-add the integration",
+                "no refresh token available — reauthentication required",
             )
             return False
 
@@ -363,7 +363,7 @@ class RestAPI:
             await self._config_manager.reset_login_details()
             self._set_status(
                 ConnectivityStatus.EXPIRED_TOKEN,
-                f"refresh failed ({ex}) — remove and re-add the integration",
+                f"refresh failed ({ex}) — reauthentication required",
             )
             return False
 

--- a/custom_components/mydolphin_plus/manifest.json
+++ b/custom_components/mydolphin_plus/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/sh00t2kill/dolphin-robot/issues",
   "requirements": ["awsiotsdk"],
-  "version": "1.0.25"
+  "version": "v1.0.26b1"
 }

--- a/custom_components/mydolphin_plus/models/config_data.py
+++ b/custom_components/mydolphin_plus/models/config_data.py
@@ -37,9 +37,7 @@ class ConfigData:
                 vol.Required(
                     CONF_TITLE, default=user_input.get(CONF_TITLE, DEFAULT_NAME)
                 ): str,
-                vol.Required(
-                    CONF_USERNAME, default=user_input.get(CONF_USERNAME)
-                ): str,
+                vol.Required(CONF_USERNAME, default=user_input.get(CONF_USERNAME)): str,
             }
         )
 

--- a/custom_components/mydolphin_plus/strings.json
+++ b/custom_components/mydolphin_plus/strings.json
@@ -15,6 +15,10 @@
         "data": {
           "otp": "Login code"
         }
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Your MyDolphin Plus session expired. Continue to sign in again with a fresh login code."
       }
     },
     "error": {
@@ -23,6 +27,9 @@
       "otp_send_failed": "Failed to send login code, check the email and try again",
       "invalid_server_details": "Invalid server details",
       "already_configured": "Integration already configured with the name"
+    },
+    "abort": {
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/custom_components/mydolphin_plus/translations/en.json
+++ b/custom_components/mydolphin_plus/translations/en.json
@@ -1,5 +1,8 @@
 {
   "config": {
+    "abort": {
+      "reauth_successful": "Reauthentication was successful"
+    },
     "error": {
       "already_configured": "Integration already configured with the name",
       "invalid_account": "Invalid account",
@@ -22,6 +25,10 @@
         },
         "description": "Enter the login code sent to your email.",
         "title": "Confirm OTP"
+      },
+      "reauth_confirm": {
+        "description": "Your MyDolphin Plus session expired. Continue to sign in again with a fresh login code.",
+        "title": "Reauthenticate MyDolphin Plus"
       }
     }
   },

--- a/custom_components/mydolphin_plus/translations/it.json
+++ b/custom_components/mydolphin_plus/translations/it.json
@@ -1,5 +1,8 @@
 {
   "config": {
+    "abort": {
+      "reauth_successful": "Riautenticazione completata"
+    },
     "error": {
       "already_configured": "Integrazione gi\u00e0 configurata con il nome",
       "invalid_account": "Account non valido",
@@ -22,6 +25,10 @@
         },
         "description": "Inserisci il codice di accesso ricevuto via email.",
         "title": "Conferma OTP"
+      },
+      "reauth_confirm": {
+        "description": "La sessione MyDolphin Plus è scaduta. Continua per accedere di nuovo con un nuovo codice di accesso.",
+        "title": "Riautentica MyDolphin Plus"
       }
     }
   },

--- a/tests/test_reauth_flow_semantics.py
+++ b/tests/test_reauth_flow_semantics.py
@@ -1,0 +1,118 @@
+"""Tests for reauthentication flow semantics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.mydolphin_plus.common.connectivity_status import (
+    ConnectivityStatus,
+)
+from custom_components.mydolphin_plus.common.consts import (
+    CONF_OTP,
+    INITIAL_TOKENS_KEY,
+    STORAGE_DATA_ID_TOKEN,
+    STORAGE_DATA_REFRESH_TOKEN,
+)
+from custom_components.mydolphin_plus.managers.coordinator import (
+    MyDolphinPlusCoordinator,
+)
+import custom_components.mydolphin_plus.managers.flow_manager as flow_manager_module
+from custom_components.mydolphin_plus.managers.flow_manager import (
+    _FLOW_STATE_ATTR,
+    IntegrationFlowManager,
+)
+from homeassistant.config_entries import SOURCE_REAUTH
+
+
+class DummyFlowHandler:
+    """Minimal flow handler for reauth tests."""
+
+    def __init__(self):
+        self.source = SOURCE_REAUTH
+        self._entry = object()
+        self.reauth_updates = None
+
+    def _get_reauth_entry(self):
+        return self._entry
+
+    def async_update_reload_and_abort(self, entry, data_updates=None):
+        self.reauth_updates = {"entry": entry, "data_updates": data_updates}
+        return {"type": "abort", "reason": "reauth_successful"}
+
+
+@pytest.mark.asyncio
+async def test_flow_manager_reauth_otp_updates_existing_entry(monkeypatch):
+    """Reauth OTP flow should update/reload existing entry instead of create."""
+    flow_handler = DummyFlowHandler()
+    setattr(
+        flow_handler,
+        _FLOW_STATE_ATTR,
+        {
+            "title": "My Dolphin",
+            "email": "user@example.com",
+            "cognito_session": "sess",
+        },
+    )
+
+    async def fake_initialize(*_args, **_kwargs):
+        return None
+
+    async def fake_respond_otp(*_args, **_kwargs):
+        return {"IdToken": "id-token", "RefreshToken": "refresh-token", "ExpiresIn": 3600}
+
+    async def fake_profile(*_args, **_kwargs):
+        return {"Sernum": "serial", "eSERNUM": "motor"}
+
+    monkeypatch.setattr(flow_manager_module, "async_get_clientsession", lambda _hass: object())
+    monkeypatch.setattr(
+        flow_manager_module.IntegrationInfo,
+        "initialize",
+        fake_initialize,
+    )
+    monkeypatch.setattr(flow_manager_module, "cognito_respond_otp", fake_respond_otp)
+    monkeypatch.setattr(flow_manager_module, "fetch_user_profile", fake_profile)
+
+    manager = IntegrationFlowManager(
+        hass=SimpleNamespace(),
+        flow_handler=flow_handler,
+        entry=flow_handler._get_reauth_entry(),
+        source=SOURCE_REAUTH,
+    )
+
+    result = await manager.async_step_otp({CONF_OTP: "123456"})
+
+    assert result["type"] == "abort"
+    assert flow_handler.reauth_updates is not None
+    updates = flow_handler.reauth_updates["data_updates"]
+    assert updates is not None
+    assert updates[INITIAL_TOKENS_KEY][STORAGE_DATA_ID_TOKEN] == "id-token"
+    assert updates[INITIAL_TOKENS_KEY][STORAGE_DATA_REFRESH_TOKEN] == "refresh-token"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_reauth_is_started_once_for_expired_token():
+    """EXPIRED_TOKEN status should trigger reauth only once."""
+    calls = {"reauth": 0, "failure": 0}
+
+    async def fake_start_reauth(_hass):
+        calls["reauth"] += 1
+
+    async def fake_handle_failure():
+        calls["failure"] += 1
+
+    coordinator = MyDolphinPlusCoordinator.__new__(MyDolphinPlusCoordinator)
+    coordinator._reauth_in_progress = False
+    coordinator.hass = object()
+    coordinator._handle_connection_failure = fake_handle_failure
+    coordinator._config_manager = SimpleNamespace(
+        entry_id="entry-id",
+        entry=SimpleNamespace(async_start_reauth=fake_start_reauth),
+    )
+
+    await coordinator._on_api_status_changed("entry-id", ConnectivityStatus.EXPIRED_TOKEN)
+    await coordinator._on_api_status_changed("entry-id", ConnectivityStatus.EXPIRED_TOKEN)
+
+    assert calls["reauth"] == 1
+    assert calls["failure"] == 2

--- a/tests/test_rest_api_semantics.py
+++ b/tests/test_rest_api_semantics.py
@@ -1,0 +1,214 @@
+"""Tests for auth headers and rate-limit semantics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from custom_components.mydolphin_plus.common.connectivity_status import (
+    ConnectivityStatus,
+)
+from custom_components.mydolphin_plus.common.consts import API_TOKEN_FIELDS
+from custom_components.mydolphin_plus.managers.config_manager import ConfigManager
+import custom_components.mydolphin_plus.managers.rest_api as rest_api_module
+from custom_components.mydolphin_plus.managers.rest_api import (
+    RestAPI,
+    cognito_initiate_auth,
+    fetch_aws_credentials,
+    fetch_user_profile,
+)
+
+
+class DummyIntegrationInfo:
+    """Simple user-agent provider used in tests."""
+
+    def set_user_agent(self, headers: dict) -> None:
+        headers["User-Agent"] = "HA-MyDolphin-Plus/test"
+
+
+class FakeResponse:
+    """Minimal async response object."""
+
+    def __init__(self, payload: dict, status: int = 200):
+        self._payload = payload
+        self.status = status
+        self.message = "error"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self) -> str:
+        import json
+
+        return json.dumps(self._payload)
+
+    async def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise Exception("http failure")
+
+
+class FakeSession:
+    """Captures request headers for assertions."""
+
+    def __init__(self, post_payload: dict | None = None, get_payload: dict | None = None):
+        self._post_payload = post_payload or {}
+        self._get_payload = get_payload or {}
+        self.last_headers: dict | None = None
+
+    def post(self, _url, headers=None, data=None):
+        self.last_headers = headers
+        return FakeResponse(self._post_payload)
+
+    def get(self, _url, headers=None):
+        self.last_headers = headers
+        return FakeResponse(self._get_payload)
+
+
+class DummyConfigManager:
+    """Config manager surface needed by RestAPI for these tests."""
+
+    def __init__(self):
+        now = datetime.now().timestamp()
+        self.id_token = "id-token"
+        self.refresh_token = "refresh-token"
+        self.id_token_expires_at = now + 3600
+        self.serial_number = None
+        self.motor_unit_serial = None
+        self.aws_credentials_expiry = 0
+        self.last_token_fetch = now
+        self.last_aws_credentials_fetch = 0
+        self.entry_id = "entry-id"
+        self.updated_aws_fetch = None
+        self.updated_aws_expiry = None
+
+    @property
+    def config_data(self):
+        return None
+
+    async def update_tokens(self, *_args, **_kwargs):
+        return None
+
+    async def reset_login_details(self):
+        return None
+
+    async def update_serial_number(self, serial_number: str):
+        self.serial_number = serial_number
+
+    async def update_motor_unit_serial(self, motor_unit_serial: str):
+        self.motor_unit_serial = motor_unit_serial
+
+    async def update_last_aws_credentials_fetch(self, timestamp: float):
+        self.updated_aws_fetch = timestamp
+        self.last_aws_credentials_fetch = timestamp
+
+    async def update_aws_credentials_expiry(self, expiry: float):
+        self.updated_aws_expiry = expiry
+        self.aws_credentials_expiry = expiry
+
+
+@pytest.mark.asyncio
+async def test_cognito_initiate_auth_sets_user_agent():
+    """Cognito initiate auth includes User-Agent headers."""
+    session = FakeSession(post_payload={"ChallengeName": "CUSTOM_CHALLENGE", "Session": "x"})
+    info = DummyIntegrationInfo()
+
+    await cognito_initiate_auth(session, "user@example.com", integration_info=info)
+
+    assert session.last_headers["User-Agent"] == "HA-MyDolphin-Plus/test"
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_profile_sets_user_agent():
+    """authenticate-user request includes User-Agent headers."""
+    session = FakeSession(post_payload={"Data": {"Sernum": "123"}})
+    info = DummyIntegrationInfo()
+
+    await fetch_user_profile(session, "id-token", integration_info=info)
+
+    assert session.last_headers["User-Agent"] == "HA-MyDolphin-Plus/test"
+    assert session.last_headers["Authorization"] == "Bearer id-token"
+
+
+@pytest.mark.asyncio
+async def test_fetch_aws_credentials_sets_user_agent():
+    """getToken request includes User-Agent headers."""
+    session = FakeSession(get_payload={"Data": {"AccessKeyId": "AKIA"}})
+    info = DummyIntegrationInfo()
+
+    await fetch_aws_credentials(session, "id-token", integration_info=info)
+
+    assert session.last_headers["User-Agent"] == "HA-MyDolphin-Plus/test"
+    assert session.last_headers["Authorization"] == "Bearer id-token"
+
+
+@pytest.mark.asyncio
+async def test_update_tokens_does_not_touch_aws_fetch_timestamp():
+    """Token refresh timestamp is decoupled from AWS fetch timestamp."""
+    manager = ConfigManager(None)
+    manager._data = {
+        "last-token-fetch": 0,
+        "last-aws-credentials-fetch": 99,
+    }
+
+    async def noop_save():
+        return None
+
+    manager._save = noop_save
+
+    await manager.update_tokens("id", "refresh", 1234567890)
+
+    assert manager.last_aws_credentials_fetch == 99
+
+
+@pytest.mark.asyncio
+async def test_refresh_aws_credentials_uses_aws_fetch_timestamp(monkeypatch):
+    """Recent token refresh should not throttle AWS credential fetch."""
+    cfg = DummyConfigManager()
+    cfg.last_token_fetch = datetime.now().timestamp()
+    cfg.last_aws_credentials_fetch = 0
+    api = RestAPI(None, cfg)
+    api._session = object()
+    api.set_local_async_dispatcher_send(lambda *_args: None)
+
+    called = {"fetch": False}
+
+    async def fake_fetch_aws_credentials(_session, _id_token, integration_info=None):
+        called["fetch"] = True
+        assert integration_info is not None
+        return {
+            "Token": "t",
+            "AccessKeyId": "ak",
+            "SecretAccessKey": "sk",
+        }
+
+    monkeypatch.setattr(rest_api_module, "fetch_aws_credentials", fake_fetch_aws_credentials)
+
+    await api._refresh_aws_credentials()
+
+    assert called["fetch"] is True
+    assert cfg.updated_aws_fetch is not None
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_with_expired_cache_sets_failed():
+    """Rate-limited path should not claim connected with expired cache."""
+    cfg = DummyConfigManager()
+    now = datetime.now().timestamp()
+    cfg.last_aws_credentials_fetch = now
+    cfg.aws_credentials_expiry = now - 60
+    api = RestAPI(None, cfg)
+    api._session = object()
+    api.set_local_async_dispatcher_send(lambda *_args: None)
+    for field in API_TOKEN_FIELDS:
+        api.data[field] = f"cached-{field}"
+
+    await api._refresh_aws_credentials()
+
+    assert api.status == ConnectivityStatus.FAILED


### PR DESCRIPTION
## Summary
- Add Home Assistant native reauthentication for expired or missing Cognito refresh tokens after the OTP login migration.
- Update Cognito, profile, and AWS token requests to include integration User-Agent headers.
- Separate AWS credential fetch tracking from Cognito token refresh tracking to avoid incorrect rate limiting.
- Mark expired cached AWS credentials as failed instead of connected when refresh is rate-limited.
- Bump version/changelog for `v1.0.26b1`.