### PR TITLE
Enhance AWS credential management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.26b2
+
+- Preserve stored Cognito tokens across Home Assistant restarts when cached AWS IoT credentials expire
+- Clear only stale AWS credential cache metadata so the integration can refresh credentials without forcing reauthentication
+
 ## v1.0.26b1
 
 - Merge pull request [#270](https://github.com/sh00t2kill/dolphin-robot/pull/270) from `yumlevi/cognito-otp-login`

--- a/custom_components/mydolphin_plus/managers/config_manager.py
+++ b/custom_components/mydolphin_plus/managers/config_manager.py
@@ -25,7 +25,6 @@ from ..common.consts import (
     DEFAULT_NAME,
     DOMAIN,
     INVALID_TOKEN_SECTION,
-    RECONNECT_BACKOFF_MAX,
     STORAGE_DATA_ID_TOKEN,
     STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
     STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH,
@@ -262,24 +261,19 @@ class ConfigManager:
         await self._save()
 
     async def _validate_cached_credentials(self):
-        """Check if cached credentials are too old and clear them if needed."""
+        """Clear stale AWS cache metadata without clearing Cognito login tokens."""
         last_fetch = self._data.get(STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH, 0) or 0
+        expiry = self._data.get(AWS_CREDENTIALS_EXPIRY, 0) or 0
 
-        if last_fetch == 0:
-            return  # No cached credentials to validate
+        if last_fetch == 0 or expiry > datetime.now().timestamp():
+            return
 
-        token_age_seconds = datetime.now().timestamp() - last_fetch
-
-        if token_age_seconds >= RECONNECT_BACKOFF_MAX.total_seconds():
-            token_age_minutes = token_age_seconds / 60
-            max_age_minutes = RECONNECT_BACKOFF_MAX.total_seconds() / 60
-
-            _LOGGER.debug(
-                f"Stored API credentials expired (age: {token_age_minutes:.1f} minutes, "
-                f"max: {max_age_minutes:.0f} minutes). "
-                "Clearing for fresh authentication."
-            )
-            await self.reset_login_details()
+        _LOGGER.debug(
+            "Stored AWS credential metadata expired. Clearing cache metadata."
+        )
+        self._data[STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH] = 0
+        self._data[AWS_CREDENTIALS_EXPIRY] = 0
+        await self._save()
 
     async def update_tokens(
         self,
@@ -368,7 +362,7 @@ class ConfigManager:
             _LOGGER.info("updated")
             await self._save()
 
-        # Validate credentials aren't too old
+        # Validate cached AWS credential metadata without invalidating login tokens.
         await self._validate_cached_credentials()
 
     @staticmethod

--- a/custom_components/mydolphin_plus/manifest.json
+++ b/custom_components/mydolphin_plus/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/sh00t2kill/dolphin-robot/issues",
   "requirements": ["awsiotsdk"],
-  "version": "v1.0.26b1"
+  "version": "v1.0.26b2"
 }

--- a/tests/test_rest_api_semantics.py
+++ b/tests/test_rest_api_semantics.py
@@ -9,7 +9,15 @@ import pytest
 from custom_components.mydolphin_plus.common.connectivity_status import (
     ConnectivityStatus,
 )
-from custom_components.mydolphin_plus.common.consts import API_TOKEN_FIELDS
+from custom_components.mydolphin_plus.common.consts import (
+    API_TOKEN_FIELDS,
+    AWS_CREDENTIALS_EXPIRY,
+    STORAGE_DATA_ID_TOKEN,
+    STORAGE_DATA_ID_TOKEN_EXPIRES_AT,
+    STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH,
+    STORAGE_DATA_LAST_TOKEN_FETCH,
+    STORAGE_DATA_REFRESH_TOKEN,
+)
 from custom_components.mydolphin_plus.managers.config_manager import ConfigManager
 import custom_components.mydolphin_plus.managers.rest_api as rest_api_module
 from custom_components.mydolphin_plus.managers.rest_api import (
@@ -165,6 +173,35 @@ async def test_update_tokens_does_not_touch_aws_fetch_timestamp():
     await manager.update_tokens("id", "refresh", 1234567890)
 
     assert manager.last_aws_credentials_fetch == 99
+
+
+@pytest.mark.asyncio
+async def test_stale_aws_cache_metadata_does_not_clear_login_tokens():
+    """Expired AWS cache metadata on startup should not force Cognito reauth."""
+    now = datetime.now().timestamp()
+    manager = ConfigManager(None)
+    manager._data = {
+        STORAGE_DATA_ID_TOKEN: "id-token",
+        STORAGE_DATA_REFRESH_TOKEN: "refresh-token",
+        STORAGE_DATA_ID_TOKEN_EXPIRES_AT: now + 3600,
+        STORAGE_DATA_LAST_TOKEN_FETCH: now,
+        STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH: now - 7200,
+        AWS_CREDENTIALS_EXPIRY: now - 60,
+    }
+    saved = {"called": False}
+
+    async def mark_saved():
+        saved["called"] = True
+
+    manager._save = mark_saved
+
+    await manager._validate_cached_credentials()
+
+    assert manager.id_token == "id-token"
+    assert manager.refresh_token == "refresh-token"
+    assert manager.last_aws_credentials_fetch == 0
+    assert manager.aws_credentials_expiry == 0
+    assert saved["called"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Preserve stored Cognito tokens across Home Assistant restarts when cached AWS IoT credentials expire.
- Clear only stale AWS credential cache metadata to allow for refreshing credentials without requiring reauthentication.
- Bump version in manifest.json to v1.0.26b2.