### PR TITLE
Update changelog and fix vacuum pause behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.26b3
+
+- Fix pause control so active robots send the power-off command instead of only acting while docked
+
 ## v1.0.26b2
 
 - Preserve stored Cognito tokens across Home Assistant restarts when cached AWS IoT credentials expire

--- a/custom_components/mydolphin_plus/managers/coordinator.py
+++ b/custom_components/mydolphin_plus/managers/coordinator.py
@@ -872,9 +872,9 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
 
     async def _vacuum_pause(self, _entity_description: EntityDescription, state):
         is_idle_state = state == VacuumActivity.DOCKED
-        _LOGGER.debug(f"Pause vacuum, State: {state}, State: {state}")
+        _LOGGER.debug(f"Pause vacuum, State: {state}")
 
-        if is_idle_state:
+        if not is_idle_state:
             self._aws_client.pause()
 
     async def _vacuum_locate(self, entity_description: EntityDescription):

--- a/custom_components/mydolphin_plus/manifest.json
+++ b/custom_components/mydolphin_plus/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/sh00t2kill/dolphin-robot/issues",
   "requirements": ["awsiotsdk"],
-  "version": "v1.0.26b2"
+  "version": "v1.0.26b3"
 }

--- a/tests/test_vacuum_actions.py
+++ b/tests/test_vacuum_actions.py
@@ -1,0 +1,42 @@
+"""Tests for vacuum action semantics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.mydolphin_plus.managers.coordinator import (
+    MyDolphinPlusCoordinator,
+)
+from homeassistant.components.vacuum import VacuumActivity
+
+
+@pytest.mark.asyncio
+async def test_vacuum_pause_stops_active_robot():
+    """Pause should send the power-off command when the robot is active."""
+    calls = {"pause": 0}
+
+    coordinator = MyDolphinPlusCoordinator.__new__(MyDolphinPlusCoordinator)
+    coordinator._aws_client = SimpleNamespace(
+        pause=lambda: calls.__setitem__("pause", calls["pause"] + 1)
+    )
+
+    await coordinator._vacuum_pause(None, VacuumActivity.CLEANING)
+
+    assert calls["pause"] == 1
+
+
+@pytest.mark.asyncio
+async def test_vacuum_pause_ignores_docked_robot():
+    """Pause should not send another power-off command while docked."""
+    calls = {"pause": 0}
+
+    coordinator = MyDolphinPlusCoordinator.__new__(MyDolphinPlusCoordinator)
+    coordinator._aws_client = SimpleNamespace(
+        pause=lambda: calls.__setitem__("pause", calls["pause"] + 1)
+    )
+
+    await coordinator._vacuum_pause(None, VacuumActivity.DOCKED)
+
+    assert calls["pause"] == 0


### PR DESCRIPTION
- Added entry for version v1.0.26b3 in CHANGELOG.md.
- Fixed vacuum pause control to send the power-off command for active robots instead of only when docked.
- Bumped version in manifest.json to v1.0.26b3.
- Added tests to verify vacuum pause functionality for active and docked states.