### PR TITLE
Preserve MyDolphin sessions through transient refresh failures

### DIFF
--- a/custom_components/mydolphin_plus/managers/config_manager.py
+++ b/custom_components/mydolphin_plus/managers/config_manager.py
@@ -260,6 +260,13 @@ class ConfigManager:
 
         await self._save()
 
+    async def invalidate_id_token(self):
+        """Discard only the short-lived IdToken, retaining the refresh token."""
+        self._data[STORAGE_DATA_ID_TOKEN] = None
+        self._data[STORAGE_DATA_ID_TOKEN_EXPIRES_AT] = 0
+
+        await self._save()
+
     async def _validate_cached_credentials(self):
         """Clear stale AWS cache metadata without clearing Cognito login tokens."""
         last_fetch = self._data.get(STORAGE_DATA_LAST_AWS_CREDENTIALS_FETCH, 0) or 0

--- a/custom_components/mydolphin_plus/managers/coordinator.py
+++ b/custom_components/mydolphin_plus/managers/coordinator.py
@@ -301,7 +301,7 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
             return
 
         try:
-            await entry.async_start_reauth(self.hass)
+            entry.async_start_reauth(self.hass)
             self._reauth_in_progress = True
             _LOGGER.warning("Started Home Assistant reauthentication flow")
         except Exception as ex:

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -35,13 +35,12 @@ from ..common.consts import (
     DATA_ROBOT_DETAILS,
     ID_TOKEN_REFRESH_WINDOW_SECONDS,
     MIN_TOKEN_FETCH_INTERVAL,
-    RECONNECT_BACKOFF_MAX,
     SIGNAL_API_STATUS,
     SIGNAL_DEVICE_NEW,
 )
 from ..common.integration_info import IntegrationInfo
 from ..models.config_data import ConfigData
-from ..models.exceptions import LoginError
+from ..models.exceptions import CognitoAuthError, CognitoRequestError, LoginError
 from .config_manager import ConfigManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -87,13 +86,25 @@ async def _cognito_call(
                 _LOGGER.debug(
                     f"Cognito {target} failed, Status: {response.status}, Body: {text}"
                 )
-                raise LoginError(f"Cognito {target} returned {response.status}")
+                try:
+                    error_type = json.loads(text).get("__type", "")
+                except json.JSONDecodeError:
+                    error_type = ""
+
+                if error_type.rsplit("#", 1)[-1] == "NotAuthorizedException":
+                    raise CognitoAuthError(
+                        f"Cognito {target} rejected authentication"
+                    )
+
+                raise CognitoRequestError(
+                    f"Cognito {target} returned {response.status}"
+                )
             return json.loads(text)
     except LoginError:
         raise
     except Exception as ex:
         _LOGGER.debug(f"Cognito {target} request failed, Error: {ex}")
-        raise LoginError(f"Cognito {target} request failed: {ex}") from ex
+        raise CognitoRequestError(f"Cognito {target} request failed: {ex}") from ex
 
 
 async def cognito_initiate_auth(
@@ -359,11 +370,17 @@ class RestAPI:
                 refresh_token,
                 integration_info=self._integration_info,
             )
-        except LoginError as ex:
+        except CognitoAuthError as ex:
             await self._config_manager.reset_login_details()
             self._set_status(
                 ConnectivityStatus.EXPIRED_TOKEN,
                 f"refresh failed ({ex}) — reauthentication required",
+            )
+            return False
+        except LoginError as ex:
+            self._set_status(
+                ConnectivityStatus.FAILED,
+                f"refresh failed ({ex}) — retaining credentials for retry",
             )
             return False
 
@@ -401,6 +418,7 @@ class RestAPI:
         url: str,
         headers: dict,
         data: str | dict | None = None,
+        retry_on_unauthorized: bool = True,
     ) -> dict | None:
         try:
             _LOGGER.debug(f"Sending {method} {url}")
@@ -415,7 +433,21 @@ class RestAPI:
                     response.raise_for_status()
                     return await response.json()
         except ClientResponseError as crex:
-            await self._handle_client_error(url, method, crex)
+            refreshed = await self._handle_client_error(
+                url, method, crex, refresh_on_unauthorized=retry_on_unauthorized
+            )
+            if refreshed and retry_on_unauthorized:
+                retry_headers = headers.copy()
+                retry_headers["Authorization"] = (
+                    f"Bearer {self._config_manager.id_token}"
+                )
+                return await self._async_send(
+                    method,
+                    url,
+                    retry_headers,
+                    data,
+                    retry_on_unauthorized=False,
+                )
         except TimeoutError:
             self._handle_server_timeout(url, method)
         except Exception as ex:
@@ -586,8 +618,12 @@ class RestAPI:
             _LOGGER.log(log_level, log_message)
 
     async def _handle_client_error(
-        self, endpoint: str, method: str, crex: ClientResponseError
-    ):
+        self,
+        endpoint: str,
+        method: str,
+        crex: ClientResponseError,
+        refresh_on_unauthorized: bool = True,
+    ) -> bool:
         message = (
             "Failed to send HTTP request, "
             f"Endpoint: {endpoint}, "
@@ -595,39 +631,25 @@ class RestAPI:
             f"HTTP Status: {crex.message} ({crex.status})"
         )
         status = ConnectivityStatus.FAILED
-        forced_log_level: int | None = None
-
         if crex.status == 401:
-            # The IdToken is rejected. If the cached token is older than the
-            # backoff window, blow it away and force re-auth so we don't hammer
-            # the API with bad credentials. Otherwise, log quietly and let
-            # _ensure_id_token_valid try a refresh on the next iteration.
-            flow = "No id token present"
+            # Refresh and retry once with a new IdToken. A second 401 is left to
+            # the coordinator's reconnect backoff to avoid retrying in a loop.
+            if not refresh_on_unauthorized:
+                self._set_status(status, f"{message}, retry after refresh failed")
+                return False
 
-            has_id_token = self._config_manager.id_token is not None
-            last_fetch = self._config_manager.last_token_fetch
+            await self._config_manager.invalidate_id_token()
+            if await self._ensure_id_token_valid():
+                _LOGGER.info("Refreshed IdToken after HTTP 401; retrying request")
+                return True
 
-            if has_id_token:
-                if last_fetch > 0:
-                    token_age_seconds = datetime.now().timestamp() - last_fetch
-
-                    if token_age_seconds >= RECONNECT_BACKOFF_MAX.total_seconds():
-                        await self._config_manager.reset_login_details()
-                        flow = "Old token, cleared for re-auth"
-                        status = ConnectivityStatus.EXPIRED_TOKEN
-                    else:
-                        flow = "Fresh token within window"
-                        forced_log_level = logging.DEBUG
-                else:
-                    flow = "Token exists but no timestamp"
-                    forced_log_level = logging.DEBUG
-
-            message = f"{message}, flow: {flow}"
+            return False
 
         elif crex.status in [404, 405]:
             status = ConnectivityStatus.API_NOT_FOUND
 
-        self._set_status(status, message, forced_log_level)
+        self._set_status(status, message)
+        return False
 
     def _handle_server_timeout(self, endpoint: str, method: str):
         message = (

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -92,9 +92,7 @@ async def _cognito_call(
                     error_type = ""
 
                 if error_type.rsplit("#", 1)[-1] == "NotAuthorizedException":
-                    raise CognitoAuthError(
-                        f"Cognito {target} rejected authentication"
-                    )
+                    raise CognitoAuthError(f"Cognito {target} rejected authentication")
 
                 raise CognitoRequestError(
                     f"Cognito {target} returned {response.status}"

--- a/custom_components/mydolphin_plus/models/exceptions.py
+++ b/custom_components/mydolphin_plus/models/exceptions.py
@@ -2,3 +2,11 @@ class LoginError(Exception):
     def __init__(self, message: str = "Failed to login"):
         super().__init__(message)
         self.error = message
+
+
+class CognitoAuthError(LoginError):
+    """Cognito explicitly rejected the authentication credentials."""
+
+
+class CognitoRequestError(LoginError):
+    """A non-authentication error occurred while calling Cognito."""

--- a/tests/test_reauth_flow_semantics.py
+++ b/tests/test_reauth_flow_semantics.py
@@ -96,7 +96,7 @@ async def test_coordinator_reauth_is_started_once_for_expired_token():
     """EXPIRED_TOKEN status should trigger reauth only once."""
     calls = {"reauth": 0, "failure": 0}
 
-    async def fake_start_reauth(_hass):
+    def fake_start_reauth(_hass):
         calls["reauth"] += 1
 
     async def fake_handle_failure():

--- a/tests/test_rest_api_semantics.py
+++ b/tests/test_rest_api_semantics.py
@@ -19,10 +19,6 @@ from custom_components.mydolphin_plus.common.consts import (
     STORAGE_DATA_REFRESH_TOKEN,
 )
 from custom_components.mydolphin_plus.managers.config_manager import ConfigManager
-from custom_components.mydolphin_plus.models.exceptions import (
-    CognitoAuthError,
-    CognitoRequestError,
-)
 import custom_components.mydolphin_plus.managers.rest_api as rest_api_module
 from custom_components.mydolphin_plus.managers.rest_api import (
     RestAPI,
@@ -30,6 +26,10 @@ from custom_components.mydolphin_plus.managers.rest_api import (
     cognito_initiate_auth,
     fetch_aws_credentials,
     fetch_user_profile,
+)
+from custom_components.mydolphin_plus.models.exceptions import (
+    CognitoAuthError,
+    CognitoRequestError,
 )
 
 

--- a/tests/test_rest_api_semantics.py
+++ b/tests/test_rest_api_semantics.py
@@ -19,9 +19,14 @@ from custom_components.mydolphin_plus.common.consts import (
     STORAGE_DATA_REFRESH_TOKEN,
 )
 from custom_components.mydolphin_plus.managers.config_manager import ConfigManager
+from custom_components.mydolphin_plus.models.exceptions import (
+    CognitoAuthError,
+    CognitoRequestError,
+)
 import custom_components.mydolphin_plus.managers.rest_api as rest_api_module
 from custom_components.mydolphin_plus.managers.rest_api import (
     RestAPI,
+    _cognito_call,
     cognito_initiate_auth,
     fetch_aws_credentials,
     fetch_user_profile,
@@ -106,6 +111,10 @@ class DummyConfigManager:
     async def reset_login_details(self):
         return None
 
+    async def invalidate_id_token(self):
+        self.id_token = None
+        self.id_token_expires_at = 0
+
     async def update_serial_number(self, serial_number: str):
         self.serial_number = serial_number
 
@@ -130,6 +139,30 @@ async def test_cognito_initiate_auth_sets_user_agent():
     await cognito_initiate_auth(session, "user@example.com", integration_info=info)
 
     assert session.last_headers["User-Agent"] == "HA-MyDolphin-Plus/test"
+
+
+@pytest.mark.asyncio
+async def test_cognito_refresh_rejection_is_an_auth_error():
+    """Only Cognito's explicit auth error invalidates a stored refresh token."""
+
+    class RejectedSession:
+        def post(self, *_args, **_kwargs):
+            return FakeResponse({"__type": "NotAuthorizedException"}, status=400)
+
+    with pytest.raises(CognitoAuthError):
+        await _cognito_call(RejectedSession(), "InitiateAuth", {})
+
+
+@pytest.mark.asyncio
+async def test_cognito_transport_failure_is_not_an_auth_error():
+    """Connectivity failures must remain retryable."""
+
+    class UnreachableSession:
+        def post(self, *_args, **_kwargs):
+            raise OSError("DNS unavailable")
+
+    with pytest.raises(CognitoRequestError):
+        await _cognito_call(UnreachableSession(), "InitiateAuth", {})
 
 
 @pytest.mark.asyncio
@@ -249,3 +282,48 @@ async def test_rate_limited_with_expired_cache_sets_failed():
     await api._refresh_aws_credentials()
 
     assert api.status == ConnectivityStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_cognito_refresh_transport_failure_retains_tokens(monkeypatch):
+    """A transport failure must not be treated as a rejected refresh token."""
+    cfg = DummyConfigManager()
+    api = RestAPI(None, cfg)
+    api._session = object()
+    api.set_local_async_dispatcher_send(lambda *_args: None)
+
+    async def transport_failure(*_args, **_kwargs):
+        raise CognitoRequestError("DNS unavailable")
+
+    monkeypatch.setattr(rest_api_module, "cognito_refresh", transport_failure)
+
+    assert await api._ensure_id_token_valid() is True
+    cfg.id_token_expires_at = 0
+    assert await api._ensure_id_token_valid() is False
+    assert cfg.refresh_token == "refresh-token"
+    assert api.status == ConnectivityStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_cognito_refresh_auth_failure_clears_tokens(monkeypatch):
+    """Only an explicit Cognito auth rejection requires reauthentication."""
+    cfg = DummyConfigManager()
+    cfg.id_token_expires_at = 0
+    cleared = {"called": False}
+
+    async def reset_login_details():
+        cleared["called"] = True
+
+    cfg.reset_login_details = reset_login_details
+    api = RestAPI(None, cfg)
+    api._session = object()
+    api.set_local_async_dispatcher_send(lambda *_args: None)
+
+    async def auth_failure(*_args, **_kwargs):
+        raise CognitoAuthError("Refresh rejected")
+
+    monkeypatch.setattr(rest_api_module, "cognito_refresh", auth_failure)
+
+    assert await api._ensure_id_token_valid() is False
+    assert cleared["called"] is True
+    assert api.status == ConnectivityStatus.EXPIRED_TOKEN


### PR DESCRIPTION
## Summary

Fixes false `Authentication expired` / forced OTP reauthentication when refreshing a MyDolphin Cognito session fails because of a transient network error.

- Distinguish an explicit Cognito authentication rejection (`NotAuthorizedException`) from transport and other request failures.
- Retain stored credentials and use normal reconnection backoff for DNS, timeout, and non-auth Cognito errors.
- On API HTTP 401, invalidate only the short-lived ID token, refresh it using the stored refresh token, and retry the request once.
- Start Home Assistant reauthentication correctly by calling `ConfigEntry.async_start_reauth()` as its synchronous callback API intends.

## Problem

A temporary DNS outage was reported as `Expired Token`, after which the integration deleted the refresh token and required a new OTP. The mobile app does not exhibit this behavior.

The integration also awaited `async_start_reauth()`, although Home Assistant Core defines it as a callback returning `None`.

## Cognito response verification

The actual Maytronics Cognito client was queried with a deliberately invalid dummy refresh token (not an account credential). It returned HTTP 400 with `x-amzn-ErrorType: NotAuthorizedException` and this JSON body:

```json
{"__type":"NotAuthorizedException","message":"Invalid Refresh Token"}
```

This confirms that checking `__type == "NotAuthorizedException"` correctly identifies a rejected refresh token. DNS, timeout, and other request failures do not receive this provider response and retain credentials for retry.

## Why `async_start_reauth()` must not be awaited

Home Assistant Core declares `ConfigEntry.async_start_reauth()` as `@callback def ... -> None`, not as a coroutine. Its implementation immediately schedules the real async work with `hass.async_create_task(...)`; it has no result to await. [Definition and scheduled task](https://github.com/home-assistant/core/blob/71494b6c97bc832810906c843b8b9d836eb3e201/homeassistant/config_entries.py#L1264-L1284)

Core itself calls this method directly when config-entry setup raises `ConfigEntryAuthFailed`. [Core call site](https://github.com/home-assistant/core/blob/71494b6c97bc832810906c843b8b9d836eb3e201/homeassistant/config_entries.py#L806-L819) Other integrations do the same; for example, HEOS calls `self.config_entry.async_start_reauth(self.hass)` with no `await`. [HEOS example](https://github.com/home-assistant/core/blob/71494b6c97bc832810906c843b8b9d836eb3e201/homeassistant/components/heos/coordinator.py#L160-L164)

Awaiting the `None` return value produced the observed error:

```text
'NoneType' object can't be awaited
```

## Testing

- Added tests for Cognito `NotAuthorizedException` versus transport failures.
- Added tests confirming transport failures retain the refresh token.
- Added tests confirming only explicit authentication rejection clears tokens.
- Updated the reauth test to match Home Assistant’s synchronous API.
- Ran `py_compile` and `git diff --check`.

### Controlled Home Assistant transport-failure test

On a Home Assistant installation already carrying PR #297, the installed #298 code was exercised without touching account credentials:

1. Backed up `custom_components/mydolphin_plus/common/consts.py`.
2. Temporarily set `COGNITO_ENDPOINT` to the closed local address `https://127.0.0.1:1/` and increased the refresh window to force an immediate Cognito refresh on restart.
3. Restarted Home Assistant and observed:

   ```text
   refresh failed (Cognito InitiateAuth request failed: Cannot connect to host 127.0.0.1:1 ...) — retaining credentials for retry
   ```

   This is the real `aiohttp` connection-error path, not a mocked Cognito response. It confirmed the failure is treated as transient: no reauthentication flow was started and the stored credentials were retained.
4. Restored the exact production endpoint and normal refresh window from the backup, restarted Home Assistant, and confirmed that MyDolphin connected and fetched AWS IoT credentials normally.

Full pytest was not run locally because `pytest` is unavailable in the workspace.

