### PR TITLE
Fix robot name encoding

### DIFF
--- a/custom_components/mydolphin_plus/common/base_entity.py
+++ b/custom_components/mydolphin_plus/common/base_entity.py
@@ -17,6 +17,17 @@ from .robot_family import RobotFamily
 _LOGGER = logging.getLogger(__name__)
 
 
+def _legacy_unique_id(
+    entity_description: MyDolphinPlusEntityDescription,
+    serial_number: str,
+    entity_name: str,
+) -> str:
+    """Keep the historical entity identity for backwards compatibility."""
+    return slugify(
+        f"{entity_description.platform}_{serial_number}_{entity_name}"
+    )
+
+
 def async_setup_entities(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -31,7 +42,6 @@ def async_setup_entities(
         robot_family = RobotFamily.from_string(robot_family_str)
 
         entity_descriptions = get_entity_descriptions(platform, robot_family)
-
         entities = [
             entity_type(entity_description, coordinator)
             for entity_description in entity_descriptions
@@ -66,10 +76,13 @@ class MyDolphinPlusBaseEntity(CoordinatorEntity):
             entity_description, device_info
         )
 
-        slugify_name = slugify(entity_name)
-
-        unique_id = slugify(
-            f"{entity_description.platform}_{serial_number}_{slugify_name}"
+        raw_device_info = dict(device_info)
+        raw_device_info["name"] = coordinator.raw_robot_name
+        raw_entity_name = coordinator.config_manager.get_entity_name(
+            entity_description, raw_device_info
+        )
+        unique_id = _legacy_unique_id(
+            entity_description, serial_number, raw_entity_name
         )
 
         self.entity_description = entity_description

--- a/custom_components/mydolphin_plus/managers/coordinator.py
+++ b/custom_components/mydolphin_plus/managers/coordinator.py
@@ -168,13 +168,18 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
         self._load_signal_handlers()
 
     @property
-    def robot_name(self):
+    def raw_robot_name(self):
         robot_name = self.api_data.get(DATA_ROBOT_NAME)
 
         if robot_name is None or robot_name == "":
             robot_name = DEFAULT_NAME
 
         return robot_name
+
+    @property
+    def robot_name(self):
+        """Return the robot name corrected for the Maytronics API encoding."""
+        return RestAPI._decode_robot_name(self.raw_robot_name)
 
     @property
     def api_data(self) -> dict:

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -455,10 +455,7 @@ class RestAPI:
 
         for key, mapped in DATA_ROBOT_DETAILS.items():
             if key in data:
-                value = data.get(key)
-                if key == "MyRobotName" and isinstance(value, str):
-                    value = self._decode_robot_name(value)
-                self.data[mapped] = value
+                self.data[mapped] = data.get(key)
 
         return True
 

--- a/custom_components/mydolphin_plus/managers/rest_api.py
+++ b/custom_components/mydolphin_plus/managers/rest_api.py
@@ -455,9 +455,20 @@ class RestAPI:
 
         for key, mapped in DATA_ROBOT_DETAILS.items():
             if key in data:
-                self.data[mapped] = data.get(key)
+                value = data.get(key)
+                if key == "MyRobotName" and isinstance(value, str):
+                    value = self._decode_robot_name(value)
+                self.data[mapped] = value
 
         return True
+
+    @staticmethod
+    def _decode_robot_name(value: str) -> str:
+        """Decode the API's Latin-1-mojibaked UTF-8 robot name value."""
+        try:
+            return value.encode("latin-1").decode("utf-8")
+        except UnicodeError:
+            return value
 
     async def _refresh_aws_credentials(self):
         # Use cached creds when still valid

--- a/tests/test_entity_unique_ids.py
+++ b/tests/test_entity_unique_ids.py
@@ -1,0 +1,19 @@
+"""Regression tests for stable MyDolphin Plus entity identities."""
+
+from types import SimpleNamespace
+
+from homeassistant.const import Platform
+
+from custom_components.mydolphin_plus.common.base_entity import (
+    _legacy_unique_id,
+)
+from homeassistant.util import slugify
+
+
+def test_unique_id_uses_the_raw_legacy_robot_name():
+    """Correcting a display name must not change an existing identity."""
+    description = SimpleNamespace(platform=Platform.LIGHT, key="led")
+
+    assert _legacy_unique_id(
+        description, "Y4708NMP4L", "PosÃ©idon LED"
+    ) == slugify("light_Y4708NMP4L_PosÃ©idon LED")

--- a/tests/test_entity_unique_ids.py
+++ b/tests/test_entity_unique_ids.py
@@ -15,5 +15,5 @@ def test_unique_id_uses_the_raw_legacy_robot_name():
     description = SimpleNamespace(platform=Platform.LIGHT, key="led")
 
     assert _legacy_unique_id(
-        description, "Y4708NMP4L", "CafÃ© LED"
-    ) == slugify("light_Y4708NMP4L_CafÃ© LED")
+        description, "TEST-7F3A9C", "CafÃ© LED"
+    ) == slugify("light_TEST-7F3A9C_CafÃ© LED")

--- a/tests/test_entity_unique_ids.py
+++ b/tests/test_entity_unique_ids.py
@@ -15,5 +15,5 @@ def test_unique_id_uses_the_raw_legacy_robot_name():
     description = SimpleNamespace(platform=Platform.LIGHT, key="led")
 
     assert _legacy_unique_id(
-        description, "Y4708NMP4L", "PosÃ©idon LED"
-    ) == slugify("light_Y4708NMP4L_PosÃ©idon LED")
+        description, "Y4708NMP4L", "CafÃ© LED"
+    ) == slugify("light_Y4708NMP4L_CafÃ© LED")

--- a/tests/test_rest_api_semantics.py
+++ b/tests/test_rest_api_semantics.py
@@ -156,6 +156,12 @@ async def test_fetch_aws_credentials_sets_user_agent():
     assert session.last_headers["Authorization"] == "Bearer id-token"
 
 
+def test_robot_name_decodes_api_mojibake():
+    """Maytronics serializes UTF-8 robot names after Latin-1 decoding."""
+    assert RestAPI._decode_robot_name("CafÃ©") == "Café"
+    assert RestAPI._decode_robot_name("Pool Robot") == "Pool Robot"
+
+
 @pytest.mark.asyncio
 async def test_update_tokens_does_not_touch_aws_fetch_timestamp():
     """Token refresh timestamp is decoupled from AWS fetch timestamp."""


### PR DESCRIPTION
## Summary

- Decode the malformed UTF-8 robot-name value returned by the Maytronics profile API for display only.
- Preserve the API's original raw name when calculating entity `unique_id`s.
- Keep existing Home Assistant entity IDs, history, customizations, dashboards, and automation references unchanged.

## Why

Maytronics can return accented robot names with UTF-8 bytes interpreted as Latin-1 (for example, `CafÃ©`). The first version of this fix decoded that value while mapping the API response. However, this integration historically derives each entity's `unique_id` from the robot/entity display name. Correcting the name at that point changed every `unique_id`.

Home Assistant consequently treated all entities as new. Because the prior entity IDs were still registered, it created duplicate entities with an `_2` suffix.

## Selected fix

The raw API value remains the compatibility-only input for the existing `unique_id` calculation. The coordinator exposes a separately decoded robot name for `DeviceInfo` and entity display names.

This intentionally avoids an entity-registry migration: users upgrading retain their established entities without `_2` duplicates or broken references, while the UI displays the corrected name.

## Validation

- `python -m compileall` passes for the changed modules.
- Applied the patch to a live Home Assistant instance and reloaded the MyDolphin Plus config entry.
- Confirmed the vacuum entity remains live and no `_2` entities were created.