### PR TITLE
Fix reauthentication flow failing to start ('NoneType' object can't be awaited)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.26
 
+- Fix reauthentication flow failing to start (`'NoneType' object can't be awaited`) — `ConfigEntry.async_start_reauth` is synchronous and must not be awaited
 - Use vacuum `activity` instead of `state` for start and pause actions (Home Assistant 2026.x forward compatibility)
 - Align HACS metadata with the integration manifest: Cloud Push `iot_class` and minimum Home Assistant 2026.1.0
 - Correct `vacuum_state` return type to `VacuumActivity` in system details

--- a/custom_components/mydolphin_plus/managers/coordinator.py
+++ b/custom_components/mydolphin_plus/managers/coordinator.py
@@ -301,7 +301,7 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
             return
 
         try:
-            await entry.async_start_reauth(self.hass)
+            entry.async_start_reauth(self.hass)
             self._reauth_in_progress = True
             _LOGGER.warning("Started Home Assistant reauthentication flow")
         except Exception as ex:


### PR DESCRIPTION
## User-visible change

On the v1.0.26 betas, when the integration detects a missing or expired refresh token it tries to launch Home Assistant's native reauthentication flow, but the launch itself fails:

```
WARNING ... Status update None --> Expired Token, no refresh token stored — reauthentication required
ERROR ... Failed to start Home Assistant reauthentication flow: 'NoneType' object can't be awaited
```

The reauth prompt never appears in Settings → Devices & Services, so affected users (including anyone upgrading from pre-OTP versions, who never had a refresh token) are stuck in a permanent reconnect loop with no way to reauthenticate from the UI.

## Cause / fix

`ConfigEntry.async_start_reauth` is a synchronous method in Home Assistant core — it schedules the reauth flow as a background task and returns `None`. Awaiting the return value raises `TypeError` inside the `try` block, before `_reauth_in_progress` is set. The fix is to call it without `await`.

## Testing

Manual, on a live install (HA 2026.7, upgrade path from v1.0.24 stable to v1.0.26b3, so no stored Cognito refresh token):

- Before: log lines above on every reconnect attempt, no reauth prompt ever shown.
- After (only this one-line change): "Started Home Assistant reauthentication flow" is logged, the reauth prompt appears in Settings → Devices & Services, and completing the emailed OTP restores the connection (id/refresh tokens stored, AWS IoT connected, no further errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)