### PR TITLE
Add start_cleaning vacuum service to start a cycle in a specific clean mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.26
 
+- Add `mydolphin_plus.start_cleaning` vacuum service to start a cleaning cycle in a specific clean mode (regular, fast, floor only, water line, ultra clean, pickup)
 - Use vacuum `activity` instead of `state` for start and pause actions (Home Assistant 2026.x forward compatibility)
 - Align HACS metadata with the integration manifest: Cloud Push `iot_class` and minimum Home Assistant 2026.1.0
 - Correct `vacuum_state` return type to `VacuumActivity` in system details

--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ The following errors can appear:
 
 ## Services
 
+### Start Cleaning
+
+The `mydolphin_plus.start_cleaning` service starts a cleaning cycle in a specific clean mode with a single call, regardless of the currently selected mode.
+
+**Available Modes:**
+
+| Mode     | Description                                          |
+| -------- | ---------------------------------------------------- |
+| `all`    | Regular - cleans floor, water and waterline          |
+| `short`  | Fast mode - shortened cleaning cycle                 |
+| `floor`  | Floor only                                           |
+| `water`  | Water line                                           |
+| `ultra`  | Ultra clean - deep cleaning of floor, water and waterline |
+| `pickup` | Pickup - drives to a collection point                |
+
+**Example:**
+
+```yaml
+# Start a floor-only cleaning cycle
+service: mydolphin_plus.start_cleaning
+target:
+  entity_id: vacuum.{Robot Name}
+data:
+  mode: floor
+```
+
 ### Remote Control
 
 The Remote entity provides virtual joystick control for manual robot navigation. Use the Remote entity's activity feature to control the robot:

--- a/custom_components/mydolphin_plus/common/consts.py
+++ b/custom_components/mydolphin_plus/common/consts.py
@@ -234,6 +234,8 @@ ATTR_ATTRIBUTES = "attributes"
 ATTR_ACTIONS = "actions"
 ATTR_INSTRUCTIONS = "instructions"
 
+SERVICE_START_CLEANING = "start_cleaning"
+
 LED_MODE_BLINKING = "1"
 LED_MODE_ALWAYS_ON = "2"
 LED_MODE_DISCO = "3"

--- a/custom_components/mydolphin_plus/managers/coordinator.py
+++ b/custom_components/mydolphin_plus/managers/coordinator.py
@@ -103,6 +103,7 @@ from ..common.consts import (
     MANUFACTURER,
     PLATFORMS,
     RECONNECT_BACKOFF_MAX,
+    SERVICE_START_CLEANING,
     SIGNAL_API_STATUS,
     SIGNAL_AWS_CLIENT_STATUS,
     UPDATE_API_INTERVAL,
@@ -565,6 +566,7 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
             ATTR_ATTRIBUTES: {ATTR_MODE: mode},
             ATTR_ACTIONS: {
                 SERVICE_START: self._vacuum_start,
+                SERVICE_START_CLEANING: self._start_cleaning,
                 SERVICE_PAUSE: self._vacuum_pause,
                 SERVICE_SET_FAN_SPEED: self._set_cleaning_mode,
                 SERVICE_LOCATE: self._vacuum_locate,
@@ -858,6 +860,15 @@ class MyDolphinPlusCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Pickup vacuum")
 
         self._aws_client.pickup()
+
+    async def _start_cleaning(
+        self, _entity_description: EntityDescription, clean_mode: str
+    ):
+        mode = CleanModes(clean_mode)
+
+        _LOGGER.debug(f"Start cleaning, Mode: {mode}")
+
+        self._aws_client.set_cleaning_mode(mode)
 
     async def _vacuum_start(self, _entity_description: EntityDescription, _state):
         _LOGGER.debug("Start vacuum")

--- a/custom_components/mydolphin_plus/services.yaml
+++ b/custom_components/mydolphin_plus/services.yaml
@@ -1,0 +1,24 @@
+start_cleaning:
+  target:
+    entity:
+      integration: mydolphin_plus
+      domain: vacuum
+  fields:
+    mode:
+      required: true
+      example: floor
+      selector:
+        select:
+          options:
+            - value: "all"
+              label: "Regular - cleans floor, water and waterline"
+            - value: "short"
+              label: "Fast mode - shortened cleaning cycle"
+            - value: "floor"
+              label: "Floor only"
+            - value: "water"
+              label: "Water line"
+            - value: "ultra"
+              label: "Ultra clean - deep cleaning of floor, water and waterline"
+            - value: "pickup"
+              label: "Pickup - drives to a collection point"

--- a/custom_components/mydolphin_plus/strings.json
+++ b/custom_components/mydolphin_plus/strings.json
@@ -281,5 +281,17 @@
         }
       }
     }
+  },
+  "services": {
+    "start_cleaning": {
+      "name": "Start cleaning",
+      "description": "Starts a cleaning cycle in a specific clean mode.",
+      "fields": {
+        "mode": {
+          "name": "Clean mode",
+          "description": "The clean mode to run."
+        }
+      }
+    }
   }
 }

--- a/custom_components/mydolphin_plus/translations/en.json
+++ b/custom_components/mydolphin_plus/translations/en.json
@@ -147,10 +147,10 @@
         "state_attributes": {
           "instructions": {
             "state": {
-              "3": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesn\u00e2\u20ac\u2122t help, contact your dealer",
-              "5": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesn\u00e2\u20ac\u2122t help, contact your dealer",
-              "7": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n3. Plug in the power supply and try to operate again.\n4. If the above doesn\u00e2\u20ac\u2122t help, please contact your dealer",
-              "9": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n 3. Plug in the power supply and try to operate again.\n4. If the above doesn\u00e2\u20ac\u2122t help, please contact your dealer"
+              "3": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesnâ€™t help, contact your dealer",
+              "5": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesnâ€™t help, contact your dealer",
+              "7": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n3. Plug in the power supply and try to operate again.\n4. If the above doesnâ€™t help, please contact your dealer",
+              "9": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n 3. Plug in the power supply and try to operate again.\n4. If the above doesnâ€™t help, please contact your dealer"
             }
           }
         }
@@ -201,10 +201,10 @@
         "state_attributes": {
           "instructions": {
             "state": {
-              "3": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesn\u00e2\u20ac\u2122t help, contact your dealer",
-              "5": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesn\u00e2\u20ac\u2122t help, contact your dealer",
-              "7": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n3. Plug in the power supply and try to operate again.\n4. If the above doesn\u00e2\u20ac\u2122t help, please contact your dealer",
-              "9": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n 3. Plug in the power supply and try to operate again.\n4. If the above doesn\u00e2\u20ac\u2122t help, please contact your dealer"
+              "3": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesnâ€™t help, contact your dealer",
+              "5": "Please follow these steps:\n1. Unplug the power supply.\n2. Clean the debris from the impeller opening.\n3. Dismantle the impeller compartment if the debris is inaccessible.\n4. Re-assemble the robot, plug in the power supply, and try to operate again.\n5. If the above doesnâ€™t help, contact your dealer",
+              "7": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n3. Plug in the power supply and try to operate again.\n4. If the above doesnâ€™t help, please contact your dealer",
+              "9": "Please follow these steps:\n1. Unplug the power supply.\n2. Remove any object or blockage from the driving system.\n 3. Plug in the power supply and try to operate again.\n4. If the above doesnâ€™t help, please contact your dealer"
             }
           }
         }
@@ -279,6 +279,18 @@
         },
         "description": "Enter the login code sent to your email.",
         "title": "Confirm OTP"
+      }
+    }
+  },
+  "services": {
+    "start_cleaning": {
+      "name": "Start cleaning",
+      "description": "Starts a cleaning cycle in a specific clean mode.",
+      "fields": {
+        "mode": {
+          "name": "Clean mode",
+          "description": "The clean mode to run."
+        }
       }
     }
   }

--- a/custom_components/mydolphin_plus/vacuum.py
+++ b/custom_components/mydolphin_plus/vacuum.py
@@ -2,6 +2,8 @@ from abc import ABC
 import logging
 from typing import Any
 
+import voluptuous as vol
+
 from homeassistant.components.vacuum import (
     SERVICE_LOCATE,
     SERVICE_PAUSE,
@@ -12,12 +14,18 @@ from homeassistant.components.vacuum import (
     VacuumActivity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_MODE, ATTR_STATE, Platform
+from homeassistant.const import ATTR_MODE, ATTR_STATE, CONF_MODE, Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .common.base_entity import MyDolphinPlusBaseEntity, async_setup_entities
-from .common.consts import ATTR_ATTRIBUTES, SIGNAL_DEVICE_NEW
+from .common.clean_modes import CleanModes
+from .common.consts import (
+    ATTR_ATTRIBUTES,
+    SERVICE_START_CLEANING,
+    SIGNAL_DEVICE_NEW,
+)
 from .common.entity_descriptions import MyDolphinPlusVacuumEntityDescription
 from .managers.coordinator import MyDolphinPlusCoordinator
 
@@ -42,6 +50,18 @@ async def async_setup_entry(
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_DEVICE_NEW, _async_device_new)
+    )
+
+    platform = entity_platform.async_get_current_platform()
+
+    platform.async_register_entity_service(
+        SERVICE_START_CLEANING,
+        {
+            vol.Required(CONF_MODE): vol.In(
+                [str(clean_mode) for clean_mode in CleanModes]
+            )
+        },
+        "async_start_cleaning",
     )
 
 
@@ -75,6 +95,10 @@ class MyDolphinPlusVacuumEntity(MyDolphinPlusBaseEntity, StateVacuumEntity, ABC)
 
     async def async_start(self) -> None:
         await self.async_execute_device_action(SERVICE_START, self.activity)
+
+    async def async_start_cleaning(self, mode: str) -> None:
+        """Start a cleaning cycle in the requested clean mode."""
+        await self.async_execute_device_action(SERVICE_START_CLEANING, mode)
 
     async def async_pause(self, **kwargs: Any) -> None:
         await self.async_execute_device_action(SERVICE_PAUSE, self.activity)


### PR DESCRIPTION
## User-visible change

Adds a `mydolphin_plus.start_cleaning` entity service on the vacuum with a required `mode` field (`all` | `short` | `floor` | `water` | `ultra` | `pickup`), so automations, scripts, and dashboards can start a cleaning cycle in a specific clean mode with a single call.

Today the clean modes are only reachable through the vacuum's fan speed, which doesn't reliably express "start a floor-only clean now":

- `vacuum.set_fan_speed` skips sending the cleaningMode command when the requested mode matches the currently selected one, so it can't be used to (re)start a cycle in the current mode.
- Chaining `vacuum.set_fan_speed` + `vacuum.start` races the MQTT state echo — `start` reads the mode from the coordinator's local state, so it can re-send the previous mode if the robot hasn't echoed the change yet.

The new service sends the cleaningMode command for the requested mode unconditionally, in one atomic call.

## Implementation

- `start_cleaning` registered as an entity service on the vacuum platform (`async_register_entity_service`, `vol.In` over `CleanModes`)
- New coordinator action that calls `aws_client.set_cleaning_mode(mode)` directly
- `services.yaml` with a mode select dropdown (labels describing each mode), plus `services` translations in `strings.json` / `translations/en.json`
- README: new "Start Cleaning" subsection under Services with a mode table and YAML example
- CHANGELOG entry

Example:

```yaml
service: mydolphin_plus.start_cleaning
target:
  entity_id: vacuum.{Robot Name}
data:
  mode: floor
```

## Testing

Manual, on a live install (HA 2026.7, Q7 robot, this branch deployed on top of current `develop`):

- Called the service from Developer Tools with `mode: floor` and later `mode: short` — the robot started a cycle in the requested mode each time, and the reported clean mode / cycle time matched.
- Mode dropdown with labels renders correctly in the automation editor and Developer Tools → Actions.
- Invalid mode values are rejected by schema validation.
- Existing start / pause / fan-speed / locate / return-to-base behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)